### PR TITLE
Fix sidebar order in modal

### DIFF
--- a/src/utils/fullProjectModal.js
+++ b/src/utils/fullProjectModal.js
@@ -44,6 +44,7 @@ export function openFullProjectModal(projectDetails) {
   }
 
   modalOverlay.appendChild(modalContainer);
+  reorderSidebarForMobile(modalContainer);
   document.body.appendChild(modalOverlay);
   return modalOverlay;
 }
@@ -111,4 +112,24 @@ function createFullProjectElement(item) {
   }
   
   return el;
+}
+
+// Helper: On small screens move sidebar elements before the preceding item
+function reorderSidebarForMobile(container) {
+  // Ensure we only run once per modal instance
+  if (container.__sidebarReordered) return;
+  container.__sidebarReordered = true;
+
+  if (window.innerWidth > 768) return;
+
+  const pairs = Array.from(container.querySelectorAll('.col-sidebar')).map((item) => ({
+    item,
+    prev: item.previousElementSibling,
+  }));
+
+  pairs.forEach(({ item, prev }) => {
+    if (prev && prev.parentNode) {
+      prev.parentNode.insertBefore(item, prev);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- add a mobile helper that reorders sidebar items
- invoke helper when building the full project modal

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8876a5c8832cbb6dee74dcf1279d