### PR TITLE
Add video hover and visibility controls

### DIFF
--- a/src/utils/fullProjectModal.js
+++ b/src/utils/fullProjectModal.js
@@ -1,4 +1,5 @@
 // src/utils/fullProjectModal.js
+import { setupVideoPlayback } from './generalUtils.js';
 
 /**
  * Opens a modal displaying the full project details.
@@ -79,6 +80,7 @@ function createFullProjectElement(item) {
       el.src = item.src;
       el.controls = true;
       el.classList.add('full-project-video');
+      setupVideoPlayback(el);
       break;
     default:
       el = document.createElement('div');

--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -83,6 +83,22 @@ export function measureTextDimensions(text, className = '', { wrap = false } = {
   return { width, height };
 }
 
+// Attach hover/touch playback behavior and pause when the video leaves the viewport
+export function setupVideoPlayback(video) {
+  const play = () => video.play();
+  const pause = () => video.pause();
+
+  video.addEventListener('mouseenter', play);
+  video.addEventListener('mouseleave', pause);
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) pause();
+    });
+  });
+  observer.observe(video);
+}
+
 
 
 
@@ -118,6 +134,8 @@ export function loadAndMeasureVideo(src, container, scale = 1) {
     video.style.position = 'absolute';
     video.controls = true;
     container.appendChild(video);
+    // Set up interactive playback behaviour
+    setupVideoPlayback(video);
     
     video.addEventListener('loadedmetadata', () => {
       // Get natural dimensions


### PR DESCRIPTION
## Summary
- add a `setupVideoPlayback` helper for hover play/pause and IntersectionObserver pause
- invoke `setupVideoPlayback` from `loadAndMeasureVideo`
- apply playback setup to full project videos

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e958db948832c83642a3a770c7267