### PR TITLE
Add video visibility pause

### DIFF
--- a/src/utils/fullProjectModal.js
+++ b/src/utils/fullProjectModal.js
@@ -1,4 +1,5 @@
 // src/utils/fullProjectModal.js
+import { setupVideoPlayback } from './generalUtils.js';
 
 /**
  * Opens a modal displaying the full project details.
@@ -79,6 +80,7 @@ function createFullProjectElement(item) {
       el.src = item.src;
       el.controls = true;
       el.classList.add('full-project-video');
+      setupVideoPlayback(el);
       break;
     default:
       el = document.createElement('div');

--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -83,6 +83,19 @@ export function measureTextDimensions(text, className = '', { wrap = false } = {
   return { width, height };
 }
 
+// Attach visibility-based pause behaviour. The video will pause
+// automatically when it leaves the viewport. No hover playback.
+export function setupVideoPlayback(video) {
+  const pause = () => video.pause();
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) pause();
+    });
+  });
+  observer.observe(video);
+}
+
 
 
 
@@ -118,6 +131,8 @@ export function loadAndMeasureVideo(src, container, scale = 1) {
     video.style.position = 'absolute';
     video.controls = true;
     container.appendChild(video);
+    // Set up interactive playback behaviour
+    setupVideoPlayback(video);
     
     video.addEventListener('loadedmetadata', () => {
       // Get natural dimensions


### PR DESCRIPTION
## Summary
- simplify `setupVideoPlayback` to only pause videos when they leave the viewport
- keep using the helper from `loadAndMeasureVideo` and the full project modal

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e958db948832c83642a3a770c7267