### PR TITLE
Add draggable cleanup

### DIFF
--- a/src/utils/physicsSetup.js
+++ b/src/utils/physicsSetup.js
@@ -67,7 +67,7 @@ export function enableDragging(engine, world, container) {
   let isDragging = false;
   let dragStart = { x: 0, y: 0 };
 
-  container.addEventListener('touchstart', (e) => {
+  const handleTouchStart = (e) => {
     if (e.touches.length === 1) {
       isDragging = false;
       dragStart = {
@@ -75,9 +75,9 @@ export function enableDragging(engine, world, container) {
         y: e.touches[0].clientY
       };
     }
-  }, { passive: true });
+  };
 
-  container.addEventListener('touchmove', (e) => {
+  const handleTouchMove = (e) => {
     if (e.touches.length === 1) {
       const dx = e.touches[0].clientX - dragStart.x;
       const dy = e.touches[0].clientY - dragStart.y;
@@ -85,16 +85,25 @@ export function enableDragging(engine, world, container) {
         isDragging = true;
       }
     }
-  }, { passive: true });
+  };
 
-  container.addEventListener('touchend', (e) => {
+  const handleTouchEnd = (e) => {
     if (!isDragging && e.target.closest('a, button, .link-text, #container')) {
       e.preventDefault();
       e.target.click();
     }
-  });
+  };
 
-  return mouseConstraint;
+  container.addEventListener('touchstart', handleTouchStart, { passive: true });
+  container.addEventListener('touchmove', handleTouchMove, { passive: true });
+  container.addEventListener('touchend', handleTouchEnd);
+
+  return function cleanupDragging() {
+    Matter.World.remove(world, mouseConstraint);
+    container.removeEventListener('touchstart', handleTouchStart);
+    container.removeEventListener('touchmove', handleTouchMove);
+    container.removeEventListener('touchend', handleTouchEnd);
+  };
 }
 
 // Set or Adjust Gravity Dynamically

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -46,6 +46,7 @@ export function setupWhatPhysics() {
   let cleanupDeviceGravityListener = () => {};
   let cleanupSyncLoop = () => {};
   let cleanupResizeHandler = () => {}; // For the return of handleResize
+  let cleanupDragging = () => {};
 
   const bodies = []; // To track all Matter bodies and their DOM elements
 
@@ -436,7 +437,7 @@ export function setupWhatPhysics() {
   // Store the returned cleanup function from syncDOMWithBodies
   cleanupSyncLoop = syncDOMWithBodies(bodies, container);
 
-  enableDragging(engine, world, container); // Assuming this handles its own cleanup if needed, or is minor
+  cleanupDragging = enableDragging(engine, world, container);
 
   const runner = Matter.Runner.create();
   Matter.Runner.run(runner, engine);
@@ -497,6 +498,9 @@ if (DEBUG) {
     if (cleanupResizeHandler) {
       cleanupResizeHandler();
       // console.log('Resize handler stopped.');
+    }
+    if (cleanupDragging) {
+      cleanupDragging();
     }
 
     // C. Stop Matter.js

--- a/src/utils/whoPhysics.js
+++ b/src/utils/whoPhysics.js
@@ -484,7 +484,7 @@ export function setupWhoPhysics() {
   createAnchors(world, container, bodies, isOnMobile);
 
   // 6. Physics runner and sync
-  enableDragging(engine, world, container);
+  const cleanupDragging = enableDragging(engine, world, container);
   const cleanupSyncLoop = syncDOMWithBodies(bodies, container);
 
   // 7. Runner
@@ -541,6 +541,9 @@ export function setupWhoPhysics() {
     }
     if (cleanupSyncLoop) { // Call the stored cleanup function
       cleanupSyncLoop();
+    }
+    if (cleanupDragging) {
+      cleanupDragging();
     }
 
     // Debug Renderer Cleanup


### PR DESCRIPTION
## Summary
- return a cleanup callback from `enableDragging`
- keep drag listeners cleaned up in teardown functions for who/what physics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e9d22161c832caa8ec43ab4844a08