### PR TITLE
Allow variable summary text sizes

### DIFF
--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -7,7 +7,8 @@
           {
             "type": "text",
             "content": "an online tshirt brand, entirely thought and built from scratch",
-            "class": "description"
+            "class": "description",
+            "size": "lg"
           },
           {
             "type": "image",
@@ -20,7 +21,8 @@
           {
             "type": "text",
             "content": "post-irony extremely online brand identity",
-            "class": "description"
+            "class": "description",
+            "size": "sm"
           },
           {
             "type": "image",
@@ -33,7 +35,8 @@
           {
             "type": "text",
             "content": "the webstore was built through a custom shopify theme development",
-            "class": "description"
+            "class": "description",
+            "size": "sm"
           },
           {
             "type": "image",
@@ -46,7 +49,8 @@
           {
             "type": "text",
             "content": "a punk-careless-memesque tone of voice for communication",
-            "class": "description"
+            "class": "description",
+            "size": "xs"
           },
           {
             "type": "video",
@@ -220,11 +224,12 @@
     "title": "postmoderno accidentale",
     "summary": {
       "elements": [
-        {
-          "type": "text",
-          "content": "a booklet exploring how photography synthesizes the post-ideological reality of the 21st century",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "a booklet exploring how photography synthesizes the post-ideological reality of the 21st century",
+            "class": "description",
+            "size": "lg"
+          },
         {
           "type": "image",
           "src": "src/assets/what/postmoderno-accidentale/copertina.webp"
@@ -233,11 +238,12 @@
           "type": "image",
           "src": "src/assets/what/postmoderno-accidentale/mockup-doppio.webp"
         },
-        {
-          "type": "text",
-          "content": "two gazes, one image: the photographer’s intent vs the accidental postmodernist meaning.",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "two gazes, one image: the photographer’s intent vs the accidental postmodernist meaning.",
+            "class": "description",
+            "size": "sm"
+          },
         {
           "type": "image",
           "src": "src/assets/what/postmoderno-accidentale/carro.webp"
@@ -246,11 +252,12 @@
           "type": "image",
           "src": "src/assets/what/postmoderno-accidentale/tipafiamme1.webp"
         },
-        {
-          "type": "text",
-          "content": "a brief analysis of memesque photography",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "a brief analysis of memesque photography",
+            "class": "description",
+            "size": "xs"
+          },
         {
           "type": "image",
           "src": "src/assets/what/postmoderno-accidentale/mockup6-7.webp"
@@ -259,11 +266,12 @@
           "type": "image",
           "src": "src/assets/what/postmoderno-accidentale/kant.webp"
         },
-        {
-          "type": "text",
-          "content": "2022",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "2022",
+            "class": "description",
+            "size": "sm"
+          },
         {
           "type": "image",
           "src": "src/assets/what/postmoderno-accidentale/ylean.webp"
@@ -430,11 +438,12 @@
     "title": "beyond the frame",
     "summary": {
       "elements": [
-        {
-          "type": "text",
-          "content": "a photo album connecting analog film photography with AI and AR.",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "a photo album connecting analog film photography with AI and AR.",
+            "class": "description",
+            "size": "lg"
+          },
         {
           "type": "image",
           "src": "src/assets/what/beyond-the-frame/copertina.webp"
@@ -443,16 +452,18 @@
           "type": "image",
           "src": "src/assets/what/beyond-the-frame/spreadC.webp"
         },
-        {
-          "type": "text",
-          "content": "2024",
-          "class": "description"
-        },
-        {
-          "type": "text",
-          "content": "expanding beyond the borders of the page, then giving life to it thanks to AI models.",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "2024",
+            "class": "description",
+            "size": "xs"
+          },
+          {
+            "type": "text",
+            "content": "expanding beyond the borders of the page, then giving life to it thanks to AI models.",
+            "class": "description",
+            "size": "sm"
+          },
         {
           "type": "image",
           "src": "src/assets/what/beyond-the-frame/lizscan.webp"
@@ -465,20 +476,22 @@
           "type": "video",
           "src": "src/assets/what/beyond-the-frame/lizposa.mp4"
         },
-        {
-          "type": "text",
-          "content": "AR is used to showcase the animation, using the physical album as a starter.",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "AR is used to showcase the animation, using the physical album as a starter.",
+            "class": "description",
+            "size": "sm"
+          },
         {
           "type": "video",
           "src": "src/assets/what/beyond-the-frame/spicegirlverticale1.mp4"
         },
-        {
-          "type": "text",
-          "content": "the album is printed and bound, meant to be used as an actual collector for the developed film.",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "the album is printed and bound, meant to be used as an actual collector for the developed film.",
+            "class": "description",
+            "size": "xs"
+          },
         {
           "type": "image",
           "src": "src/assets/what/beyond-the-frame/spread2V.webp"
@@ -652,29 +665,32 @@
   "title": "parolo wines label",
   "summary": {
     "elements": [
-      {
-        "type": "text",
-        "content": "a wine label design for a small wine production in Valtellina, Italy",
-        "class": "description"
-      },
+        {
+          "type": "text",
+          "content": "a wine label design for a small wine production in Valtellina, Italy",
+          "class": "description",
+          "size": "lg"
+        },
       {
         "type": "image",
         "src": "src/assets/what/parolo-wines-label/Strebottiglie.webp"
       },
-      {
-        "type": "text",
-        "content": "a playful design that uses regional myths about UFOs sightings to catch attention",
-        "class": "description"
-      },
+        {
+          "type": "text",
+          "content": "a playful design that uses regional myths about UFOs sightings to catch attention",
+          "class": "description",
+          "size": "sm"
+        },
       {
         "type": "image",
         "src": "src/assets/what/parolo-wines-label/Sfinal.webp"
       },
-      {
-        "type": "text",
-        "content": "made using AI outpainting techniques with open source models.",
-        "class": "description"
-      },
+        {
+          "type": "text",
+          "content": "made using AI outpainting techniques with open source models.",
+          "class": "description",
+          "size": "xs"
+        },
       {
         "type": "image",
         "src": "src/assets/what/parolo-wines-label/Sneroiniziale.webp"
@@ -683,11 +699,12 @@
         "type": "image",
         "src": "src/assets/what/parolo-wines-label/Snerooutp.webp"
       },
-      {
-        "type": "text",
-        "content": "different versions where made with this technique",
-        "class": "description"
-      },
+        {
+          "type": "text",
+          "content": "different versions where made with this technique",
+          "class": "description",
+          "size": "sm"
+        },
       {
         "type": "image",
         "src": "src/assets/what/parolo-wines-label/Sbiancofinale.webp"
@@ -696,11 +713,12 @@
         "type": "image",
         "src": "src/assets/what/parolo-wines-label/Sdasotto.webp"
       },
-      {
-        "type": "text",
-        "content": "2025",
-        "class": "description"
-      }
+        {
+          "type": "text",
+          "content": "2025",
+          "class": "description",
+          "size": "xs"
+        }
     ]
   },
   "details": {
@@ -897,16 +915,18 @@
     "title": "archive",
     "summary": {
       "elements": [
-        {
-          "type": "text",
-          "content": "a collection of less relevant artefacts to show you the other stuff I have made",
-          "class": "description"
-        },
-        {
-          "type": "text",
-          "content": "i can screenprint and bookbind",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "a collection of less relevant artefacts to show you the other stuff I have made",
+            "class": "description",
+            "size": "lg"
+          },
+          {
+            "type": "text",
+            "content": "i can screenprint and bookbind",
+            "class": "description",
+            "size": "sm"
+          },
         {
           "type": "video",
           "src": "src/assets/what/archive/screenprint2.mp4"
@@ -915,47 +935,52 @@
           "type": "image",
           "src": "src/assets/what/archive/libricinitagliati.webp"
         },
-        {
-          "type": "text",
-          "content": "make flyers for events",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "make flyers for events",
+            "class": "description",
+            "size": "sm"
+          },
         {
           "type": "image",
           "src": "src/assets/what/archive/www1s.webp"
         },
-        {
-          "type": "text",
-          "content": "do live audioreactive visuals",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "do live audioreactive visuals",
+            "class": "description",
+            "size": "xs"
+          },
         {
           "type": "image",
           "src": "src/assets/what/archive/performancefoto.webp"
         },
-        {
-          "type": "text",
-          "content": "design menus and typefaces",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "design menus and typefaces",
+            "class": "description",
+            "size": "sm"
+          },
         {
           "type": "image",
           "src": "src/assets/what/archive/menufront.webp"
         },
-        {
-          "type": "text",
-          "content": "make tiktoks",
-          "class": "description"
-        },
+          {
+            "type": "text",
+            "content": "make tiktoks",
+            "class": "description",
+            "size": "xs"
+          },
         {
           "type": "image",
           "src": "src/assets/what/archive/boh.webp"
         },
-        {
-          "type": "text",
-          "content": "and more",
-          "class": "description"
-        }
+          {
+            "type": "text",
+            "content": "and more",
+            "class": "description",
+            "size": "xs"
+          }
       ]
     },
     "details": {

--- a/src/style.css
+++ b/src/style.css
@@ -205,22 +205,43 @@ img {
   box-shadow: 2px 2px 0 #000;
 }
 
-.description-text,
 .details-text,
 .credits-text,
-.project-text {
-  display: block; /* `fit-content` works best with block-level elements */
-  width: -moz-fit-content; /* Firefox Tweak */
-  width: fit-content;      /* Standard */
-  
-  margin-left: auto;   /* This will center the 'fit-content' block itself */
-  margin-right: auto;  /* if its parent allows (e.g., if #container is full width) */
+.project-text,
+.archive-title {
+  display: block;
+  width: -moz-fit-content;
+  width: fit-content;
+  max-width: min(36ch, 85vw);
+  margin-left: auto;
+  margin-right: auto;
+  white-space: pre-line;
+  text-align: center;
+}
 
-  white-space: pre-line; /* You need this to respect newline characters in your text */
-  text-align: center;    /* This will center the text *within* the now tighter box */
+.archive-title {
+  font-size: 1.3rem;
+  font-weight: bold;
+  margin: 0.5rem 0;
+}
 
-  /* Optional: Add some padding if you want space between the text and the physics box edge */
-  /* padding: 3px 8px; */ 
+.summary-xs { font-size: clamp(1rem, 1vw + .2rem, 1.05rem); }
+.summary-sm { font-size: clamp(1.1rem, 1.1vw + .25rem, 1.25rem); }
+.summary-lg { font-size: clamp(1.3rem, 1.2vw + .35rem, 1.55rem); }
+
+/* shared layout for all summary classes */
+.description-text,
+.summary-xs, .summary-sm, .summary-lg {
+  max-inline-size: 36ch;
+  inline-size: fit-content;
+  line-height: 1.35;
+  white-space: normal;
+  text-wrap: balance;
+  margin-block: var(--space-2);
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
 }
 
 /* Apply max-width within media queries */
@@ -238,21 +259,33 @@ img {
   }
 
   .description-text,
+  .summary-xs,
+  .summary-sm,
+  .summary-lg {
+    max-inline-size: 90%;
+    inline-size: 90%;
+    line-height: 1.45;
+  }
+
   .details-text,
   .credits-text,
-  .project-text {
-    max-width: 85vw; /* Adjust as needed, e.g., 80vw or 90vw */
-                     /* This acts as the upper limit for fit-content */
+  .project-text,
+  .archive-title {
+    max-width: min(36ch, 85vw);
   }
 }
 
 /* Desktop adjustments (if you want different max-widths) */
 @media (min-width: 769px) { /* Example desktop breakpoint */
   .description-text,
+  .summary-xs,
+  .summary-sm,
+  .summary-lg,
   .details-text,
   .credits-text,
-  .project-text {
-    max-width: 700px; /* Or your preferred desktop max-width */
+  .project-text,
+  .archive-title {
+    max-inline-size: 36ch;
   }
 }
 
@@ -295,6 +328,12 @@ img {
   border-radius: 28px;
   box-shadow: 4px 4px 0 black;
   scrollbar-gutter: stable;
+}
+.modal-container::after {
+  content: '';
+  display: block;
+  height: 100px;      /* extra white space for smooth scroll-end */
+  grid-column: 1 / -1; /* span full grid width */
 }
 
 .col-span-1 { grid-column: span 1; }

--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -47,12 +47,26 @@ export function measureTextDimensions(text, className = '', { wrap = false } = {
   temp.style.visibility= 'hidden';
   temp.style.display   = 'inline-block';     // 👈   important
   if (!wrap) temp.style.whiteSpace = 'nowrap';
-  if (className) temp.classList.add(className);
+  if (className) {
+    if (Array.isArray(className)) temp.classList.add(...className);
+    else temp.classList.add(...String(className).split(' '));
+  }
 
   document.body.appendChild(temp);
   const { width, height } = temp.getBoundingClientRect();
   document.body.removeChild(temp);
   return { width, height };
+}
+
+export async function measureTextDimensionsAfterFonts(text, className = '', opts = {}) {
+  try {
+    if (document.fonts && document.fonts.ready) {
+      await document.fonts.ready;
+    }
+  } catch (e) {
+    // ignore font readiness errors
+  }
+  return measureTextDimensions(text, className, opts);
 }
 
 

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -14,7 +14,8 @@ import {
 import projectsData from '../data/projects.json';
 import {
   spawnCenterText,
-  measureTextDimensions, 
+  measureTextDimensions,
+  measureTextDimensionsAfterFonts,
   loadAndMeasureImage,
   loadAndMeasureVideo
 } from './generalUtils.js';
@@ -122,22 +123,27 @@ export function setupWhatPhysics() {
       domElement.classList.add('project-video');
 /* ── TEXT ELEMENTS ─────────────────────────────────────────── */
 } else if (elementData.type === 'text') {
-  // 1 ▸ decide CSS class
-  const cssClass = (() => {
+  // 1 ▸ decide CSS classes
+  const cssClasses = (() => {
     switch (elementData.class) {
-      case 'description': return 'description-text';
-      case 'details':     return 'details-text';
-      case 'credits':     return 'credits-text';
-      default:            return 'project-text';
+      case 'description': {
+        const arr = ['description-text'];
+        if (elementData.size) arr.push(`summary-${elementData.size}`);
+        return arr;
+      }
+      case 'details':       return ['details-text'];
+      case 'credits':       return ['credits-text'];
+      case 'archive-title': return ['archive-title'];
+      default:              return ['project-text'];
     }
   })();
   const summaryText = elementData.content.split('. ')[0];
 
-  // Measure with wrapping, relying on the CSS class for fit-content
-  const { width: rawW, height: rawH } = measureTextDimensions(
+  // Measure after fonts load so physics body matches final text size
+  const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     summaryText,
-    cssClass,
-    { wrap: true } // This flag might be less important now if class has white-space: pre-line
+    cssClasses,
+    { wrap: true }
   );
 
   measuredWidth  = rawW * currentTextBodyScale; // currentTextBodyScale is likely 1.0
@@ -145,7 +151,7 @@ export function setupWhatPhysics() {
 
   domElement = document.createElement('div');
   domElement.innerHTML = summaryText.replace(/\n/g, '<br>');
-  domElement.classList.add(cssClass); // Applies display:block, width:fit-content, etc.
+  domElement.classList.add(...cssClasses); // Applies display:block, width:fit-content, etc.
   // domElement.style.display = 'inline-table'; // REMOVE this if you were experimenting
   // domElement.style.display = 'inline-block'; // REMOVE this
   container.appendChild(domElement);


### PR DESCRIPTION
## Summary
- support three font sizes for summary items
- annotate summary JSON with size values
- measure text using all CSS classes
- add responsive summary styling
- enlarge archive-title text

## Testing
- `npm run test`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_686f84cf905c832c9fc1b06661641db0