### PR TITLE
Align text measurement with CSS

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -238,6 +238,8 @@ img {
   text-wrap: balance;
   margin-block: var(--space-2);
   display: block;
+  width: -moz-fit-content;
+  width: fit-content;
   margin-left: auto;
   margin-right: auto;
   text-align: center;

--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -42,11 +42,13 @@ export function spawnCenterText(world, container, text, options = {}) {
 
 export function measureTextDimensions(text, className = '', { wrap = false } = {}) {
   const temp = document.createElement('div');
-  temp.textContent     = text;
-  temp.style.position  = 'absolute';
-  temp.style.visibility= 'hidden';
-  temp.style.display   = 'inline-block';     // 👈   important
-  if (!wrap) temp.style.whiteSpace = 'nowrap';
+  temp.textContent = text;
+  temp.style.position = 'absolute';
+  temp.style.visibility = 'hidden';
+  // Allow CSS classes to dictate display and wrapping behaviour
+  if (!wrap) {
+    temp.style.whiteSpace = 'nowrap';
+  }
   if (className) {
     if (Array.isArray(className)) temp.classList.add(...className);
     else temp.classList.add(...String(className).split(' '));

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -139,7 +139,8 @@ export function setupWhatPhysics() {
   })();
   const summaryText = elementData.content.split('. ')[0];
 
-  // Measure after fonts load so physics body matches final text size
+  // Measure after fonts load so physics body matches final text size.
+  // Passing { wrap: true } ensures the text wraps exactly like in the page.
   const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     summaryText,
     cssClasses,


### PR DESCRIPTION
## Summary
- adjust `measureTextDimensions` so CSS controls layout
- clarify summary text measurement call
- shrink summary text blocks to their content width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68712e4e9d60832c910bc07a5265e7a9