### PR TITLE
Assign done colour when microtexts or slides complete

### DIFF
--- a/src/utils/doneColor.js
+++ b/src/utils/doneColor.js
@@ -1,0 +1,6 @@
+export function markDone(element) {
+  if (!element) return;
+  const color = element.dataset.highlightColor || window.__navHighlightColor || '#ff0000';
+  element.style.color = color;
+  element.dataset.done = 'true';
+}

--- a/src/utils/highlightOnTouch.js
+++ b/src/utils/highlightOnTouch.js
@@ -2,7 +2,7 @@ import Matter from 'matter-js';
 
 export function enableHighlightOnTouch(engine, bodies, options = {}) {
   const reactiveClass = options.reactiveClass || 'touch-reactive';
-  const highlightColor = options.highlightColor || '#ff0000';
+  const defaultColor = options.highlightColor || '#ff0000';
 
   const bodyToElement = new Map();
   const collisionCounts = new Map();
@@ -26,12 +26,18 @@ export function enableHighlightOnTouch(engine, bodies, options = {}) {
       if (elA && elA.classList.contains(reactiveClass) && isTrigger(pair.bodyB)) {
         const c = (collisionCounts.get(elA) || 0) + 1;
         collisionCounts.set(elA, c);
-        if (c === 1) elA.style.color = highlightColor;
+        if (c === 1) {
+          const color = elA.dataset.highlightColor || defaultColor;
+          elA.style.color = color;
+        }
       }
       if (elB && elB.classList.contains(reactiveClass) && isTrigger(pair.bodyA)) {
         const c = (collisionCounts.get(elB) || 0) + 1;
         collisionCounts.set(elB, c);
-        if (c === 1) elB.style.color = highlightColor;
+        if (c === 1) {
+          const color = elB.dataset.highlightColor || defaultColor;
+          elB.style.color = color;
+        }
       }
     });
   };
@@ -44,7 +50,11 @@ export function enableHighlightOnTouch(engine, bodies, options = {}) {
         const c = (collisionCounts.get(elA) || 0) - 1;
         if (c <= 0) {
           collisionCounts.delete(elA);
-          elA.style.color = originalColors.get(elA) || '#000';
+          if (elA.dataset.done === 'true') {
+            elA.style.color = elA.dataset.highlightColor || defaultColor;
+          } else {
+            elA.style.color = originalColors.get(elA) || '#000';
+          }
         } else {
           collisionCounts.set(elA, c);
         }
@@ -53,7 +63,11 @@ export function enableHighlightOnTouch(engine, bodies, options = {}) {
         const c = (collisionCounts.get(elB) || 0) - 1;
         if (c <= 0) {
           collisionCounts.delete(elB);
-          elB.style.color = originalColors.get(elB) || '#000';
+          if (elB.dataset.done === 'true') {
+            elB.style.color = elB.dataset.highlightColor || defaultColor;
+          } else {
+            elB.style.color = originalColors.get(elB) || '#000';
+          }
         } else {
           collisionCounts.set(elB, c);
         }

--- a/src/utils/navButtons.js
+++ b/src/utils/navButtons.js
@@ -2,7 +2,14 @@ import Matter from 'matter-js';
 import { measureTextDimensions } from './generalUtils.js';
 
 // Color palette for highlight
-const PRIMARY_COLORS = ['#FF0000', '#FFFF00', '#0000FF', '#FFA500', '#008000'];
+const PRIMARY_COLORS = [
+  '#FF0000', // red
+  '#0000FF', // blue
+  '#FFFF00', // yellow
+  '#FFA500', // orange
+  '#008000', // green
+  '#800080'  // purple
+];
 
 // Utility: pick a random color
 export function pickRandomPrimary() {

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -19,9 +19,10 @@ import {
   loadAndMeasureImage,
   loadAndMeasureVideo
 } from './generalUtils.js';
-import { createPhysicsNavMenu } from './navButtons.js';
+import { createPhysicsNavMenu, pickRandomPrimary } from './navButtons.js';
 import { createWhatProjectNav } from './whatNav.js'; // Ensure class name 'what-nav-button' is used by this
 import { openFullProjectModal } from './fullProjectModal.js';
+import { markDone } from './doneColor.js';
 
 const MOBILE_SCALING = {
   image: 0.45, // e.g., images are 45% of their desktop summary size on mobile
@@ -93,6 +94,8 @@ export function setupWhatPhysics() {
     projects[currentProjectIndex].title,
     { tag: 'h1', className: 'whatpage-title' }
   );
+  // Assign a random highlight colour so it can persist after completion
+  titleDom.dataset.highlightColor = pickRandomPrimary();
   bodies.push({ body: titleBody, domElement: titleDom });
 
   // Position the title: center on desktop, lower on mobile
@@ -342,6 +345,8 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       if (currentElementIndex === summaryElements.length) {
         const buttonData = { type: 'button', content: 'View Full Project' };
         await addProjectElement(buttonData, x + (Math.random()*40-20), y + (Math.random()*40-20)); // Slight offset
+        // All summary elements spawned - mark title as done
+        markDone(titleDom);
       }
     } else {
       // Advance to the next project
@@ -365,6 +370,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       );
       titleBody = newTitleData.body;
       titleDom = newTitleData.domElement;
+      titleDom.dataset.highlightColor = pickRandomPrimary();
       bodies.push({ body: titleBody, domElement: titleDom });
       Matter.Body.setPosition(
         titleBody,
@@ -424,6 +430,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     );
     titleBody = newTitleData.body;
     titleDom = newTitleData.domElement;
+    titleDom.dataset.highlightColor = pickRandomPrimary();
     bodies.push({ body: titleBody, domElement: titleDom });
     Matter.Body.setPosition(
       titleBody,

--- a/src/utils/whoPhysics.js
+++ b/src/utils/whoPhysics.js
@@ -12,8 +12,9 @@ import {
   isMobile
 } from './physicsSetup.js';
 import { loadAndMeasureImage } from './generalUtils.js';
-import { createPhysicsNavMenu } from './navButtons.js';
+import { createPhysicsNavMenu, pickRandomPrimary } from './navButtons.js';
 import { enableHighlightOnTouch } from './highlightOnTouch.js';
+import { markDone } from './doneColor.js';
 import { ANCHORS } from '../data/who_text.js';
 
 // --- Ragdoll asset imports ---
@@ -123,6 +124,8 @@ function createAnchors(world, container, bodies, isOnMobile) {
     el.textContent = displayText;
     el.className = anchor.size === "big" ? "anchor-big anchor" : "anchor-small anchor";
     el.classList.add('touch-reactive');
+    // Assign a random highlight color for collision feedback
+    el.dataset.highlightColor = pickRandomPrimary();
      // Add any other classes based on anchor.class if you have that property
     if (anchor.class) { // Assuming you might have a general 'class' property for anchors
         el.classList.add(anchor.class);
@@ -171,6 +174,9 @@ function createAnchors(world, container, bodies, isOnMobile) {
         // Pass the determined coordinates (either from touch or click)
         spawnMicroText(world, container, bodies, micro, coordsToUse, microIdx);
       });
+
+      // Mark anchor as done and keep its highlight colour
+      markDone(el);
 
       lastTouchCoords = null; // Reset for the next interaction
     });


### PR DESCRIPTION
## Summary
- add `markDone` helper to keep a text element coloured once complete
- keep highlight colour when collision ends if element is marked done
- update who anchors to mark themselves done after spawning texts
- colour whatpage titles once all slides are spawned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68751d333d98832cb1de886cc6726bd2