### PR TITLE
sei colori

### DIFF
--- a/src/pages/homepage.js
+++ b/src/pages/homepage.js
@@ -1,13 +1,8 @@
 
 import { requestIOSMotionPermission } from '../utils/iosPermission.js';
+import { pickDistinct, persist, nextColour } from '../utils/colorEngine.js';
 
-const COLORS = ["#FF0000", "#0000FF", "#FFFF00"];
 const TILT_THRESHOLD = 20; // degrees; tweak as needed
-
-function getRandomColor(exclude) {
-  const available = COLORS.filter(c => c !== exclude);
-  return available[Math.floor(Math.random() * available.length)];
-}
 
 function setupGyroColorSwitch(topDiv, bottomDiv, threshold = TILT_THRESHOLD) {
   let lastTop = null, lastBottom = null;
@@ -16,13 +11,13 @@ function setupGyroColorSwitch(topDiv, bottomDiv, threshold = TILT_THRESHOLD) {
   function handleOrientation(event) {
     const { beta } = event;
     if (beta > threshold && currentState !== "top") {
-      const color = getRandomColor(lastTop);
+      const color = pickDistinct(lastTop, [lastBottom]);
       topDiv.style.background = color;
       bottomDiv.style.background = "#fff";
       lastTop = color;
       currentState = "top";
     } else if (beta < -threshold && currentState !== "bottom") {
-      const color = getRandomColor(lastBottom);
+      const color = pickDistinct(lastBottom, [lastTop]);
       bottomDiv.style.background = color;
       topDiv.style.background = "#fff";
       lastBottom = color;
@@ -60,10 +55,14 @@ export function renderHomepage(app) {
 
   // Routing
   whoDiv.addEventListener("click", () => {
+    const color = whoDiv.style.background || nextColour('home-split', 'cycle');
+    persist('homeColour', color, 'session');
     history.pushState({}, "", "/who");
     window.dispatchEvent(new PopStateEvent("popstate"));
   });
   whatDiv.addEventListener("click", () => {
+    const color = whatDiv.style.background || nextColour('home-split', 'cycle');
+    persist('homeColour', color, 'session');
     history.pushState({}, "", "/what");
     window.dispatchEvent(new PopStateEvent("popstate"));
   });
@@ -72,7 +71,7 @@ export function renderHomepage(app) {
   let lastWhoColor = null, lastWhatColor = null;
   whoDiv.addEventListener("mouseenter", () => {
     if (window.innerWidth > 800) {
-      const color = getRandomColor(lastWhoColor);
+      const color = pickDistinct(lastWhoColor, [lastWhatColor]);
       whoDiv.style.background = color;
       lastWhoColor = color;
     }
@@ -82,7 +81,7 @@ export function renderHomepage(app) {
   });
   whatDiv.addEventListener("mouseenter", () => {
     if (window.innerWidth > 800) {
-      const color = getRandomColor(lastWhatColor);
+      const color = pickDistinct(lastWhatColor, [lastWhoColor]);
       whatDiv.style.background = color;
       lastWhatColor = color;
     }

--- a/src/utils/colorEngine.js
+++ b/src/utils/colorEngine.js
@@ -18,6 +18,7 @@ function pickDistinct(last, avoid = []) {
 }
 
 function nextColour(key, strategy = 'cycle') {
+  if (key == null) key = 'default';
   if (strategy === 'cycle') {
     const idx = cycleState[key] || 0;
     cycleState[key] = (idx + 1) % PALETTE.length;

--- a/src/utils/colorEngine.js
+++ b/src/utils/colorEngine.js
@@ -1,0 +1,53 @@
+const PALETTE = [
+  '#ff1d25', // red
+  '#ff931e', // orange
+  '#ffef00', // yellow
+  '#00a650', // green
+  '#0072ce', // blue
+  '#9b26b6'  // purple
+];
+
+const cycleState = {};
+
+function pickDistinct(last, avoid = []) {
+  const avoidSet = new Set(avoid);
+  if (last) avoidSet.add(last);
+  const options = PALETTE.filter(c => !avoidSet.has(c));
+  if (options.length === 0) return PALETTE[0];
+  return options[Math.floor(Math.random() * options.length)];
+}
+
+function nextColour(key, strategy = 'cycle') {
+  if (strategy === 'cycle') {
+    const idx = cycleState[key] || 0;
+    cycleState[key] = (idx + 1) % PALETTE.length;
+    return PALETTE[idx % PALETTE.length];
+  }
+  if (strategy === 'hash') {
+    let hash = 0;
+    for (let i = 0; i < key.length; i++) {
+      hash = (hash << 5) - hash + key.charCodeAt(i);
+      hash |= 0;
+    }
+    return PALETTE[Math.abs(hash) % PALETTE.length];
+  }
+  return PALETTE[0];
+}
+
+function persist(key, colour, store = 'local') {
+  try {
+    const s = store === 'session' ? window.sessionStorage : window.localStorage;
+    s.setItem(key, colour);
+  } catch (e) {}
+}
+
+function recall(key, store = 'local') {
+  try {
+    const s = store === 'session' ? window.sessionStorage : window.localStorage;
+    return s.getItem(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+export { PALETTE, pickDistinct, nextColour, persist, recall };

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -19,7 +19,8 @@ import {
   loadAndMeasureImage,
   loadAndMeasureVideo
 } from './generalUtils.js';
-import { createPhysicsNavMenu, pickRandomPrimary } from './navButtons.js';
+import { createPhysicsNavMenu } from './navButtons.js';
+import { nextColour } from './colorEngine.js';
 import { createWhatProjectNav } from './whatNav.js'; // Ensure class name 'what-nav-button' is used by this
 import { openFullProjectModal } from './fullProjectModal.js';
 import { markDone } from './doneColor.js';
@@ -94,8 +95,8 @@ export function setupWhatPhysics() {
     projects[currentProjectIndex].title,
     { tag: 'h1', className: 'whatpage-title' }
   );
-  // Assign a random highlight colour so it can persist after completion
-  titleDom.dataset.highlightColor = pickRandomPrimary();
+  // Assign a stable colour per project slug using the colour engine
+  titleDom.dataset.highlightColor = nextColour(projects[currentProjectIndex].slug, 'hash');
   bodies.push({ body: titleBody, domElement: titleDom });
 
   // Position the title: center on desktop, lower on mobile
@@ -370,7 +371,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       );
       titleBody = newTitleData.body;
       titleDom = newTitleData.domElement;
-      titleDom.dataset.highlightColor = pickRandomPrimary();
+      titleDom.dataset.highlightColor = nextColour(projects[currentProjectIndex].slug, 'hash');
       bodies.push({ body: titleBody, domElement: titleDom });
       Matter.Body.setPosition(
         titleBody,
@@ -430,7 +431,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     );
     titleBody = newTitleData.body;
     titleDom = newTitleData.domElement;
-    titleDom.dataset.highlightColor = pickRandomPrimary();
+    titleDom.dataset.highlightColor = nextColour(projects[currentProjectIndex].slug, 'hash');
     bodies.push({ body: titleBody, domElement: titleDom });
     Matter.Body.setPosition(
       titleBody,

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -25,6 +25,10 @@ import { createWhatProjectNav } from './whatNav.js'; // Ensure class name 'what-
 import { openFullProjectModal } from './fullProjectModal.js';
 import { markDone } from './doneColor.js';
 
+// Simple slug generator from a string title
+const slugify = (str) =>
+  str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+
 const MOBILE_SCALING = {
   image: 0.45, // e.g., images are 45% of their desktop summary size on mobile
   video: 0.1,  // Videos might need more aggressive scaling due to their original size
@@ -95,8 +99,9 @@ export function setupWhatPhysics() {
     projects[currentProjectIndex].title,
     { tag: 'h1', className: 'whatpage-title' }
   );
-  // Assign a stable colour per project slug using the colour engine
-  titleDom.dataset.highlightColor = nextColour(projects[currentProjectIndex].slug, 'hash');
+  // Assign a stable colour based on a slug from the project title
+  const firstSlug = slugify(projects[currentProjectIndex].title);
+  titleDom.dataset.highlightColor = nextColour(firstSlug, 'hash');
   bodies.push({ body: titleBody, domElement: titleDom });
 
   // Position the title: center on desktop, lower on mobile
@@ -371,7 +376,8 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       );
       titleBody = newTitleData.body;
       titleDom = newTitleData.domElement;
-      titleDom.dataset.highlightColor = nextColour(projects[currentProjectIndex].slug, 'hash');
+      const newSlug = slugify(projects[currentProjectIndex].title);
+      titleDom.dataset.highlightColor = nextColour(newSlug, 'hash');
       bodies.push({ body: titleBody, domElement: titleDom });
       Matter.Body.setPosition(
         titleBody,
@@ -431,7 +437,8 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     );
     titleBody = newTitleData.body;
     titleDom = newTitleData.domElement;
-    titleDom.dataset.highlightColor = nextColour(projects[currentProjectIndex].slug, 'hash');
+    const navSlug = slugify(projects[currentProjectIndex].title);
+    titleDom.dataset.highlightColor = nextColour(navSlug, 'hash');
     bodies.push({ body: titleBody, domElement: titleDom });
     Matter.Body.setPosition(
       titleBody,

--- a/src/utils/whoPhysics.js
+++ b/src/utils/whoPhysics.js
@@ -12,7 +12,8 @@ import {
   isMobile
 } from './physicsSetup.js';
 import { loadAndMeasureImage } from './generalUtils.js';
-import { createPhysicsNavMenu, pickRandomPrimary } from './navButtons.js';
+import { createPhysicsNavMenu } from './navButtons.js';
+import { nextColour, persist, recall } from './colorEngine.js';
 import { enableHighlightOnTouch } from './highlightOnTouch.js';
 import { markDone } from './doneColor.js';
 import { ANCHORS } from '../data/who_text.js';
@@ -124,8 +125,11 @@ function createAnchors(world, container, bodies, isOnMobile) {
     el.textContent = displayText;
     el.className = anchor.size === "big" ? "anchor-big anchor" : "anchor-small anchor";
     el.classList.add('touch-reactive');
-    // Assign a random highlight color for collision feedback
-    el.dataset.highlightColor = pickRandomPrimary();
+    // Determine or recall a highlight colour for this anchor
+    const stored = recall(anchor.id);
+    const color = stored || nextColour('who-anchor', 'cycle');
+    if (!stored) persist(anchor.id, color);
+    el.dataset.highlightColor = color;
      // Add any other classes based on anchor.class if you have that property
     if (anchor.class) { // Assuming you might have a general 'class' property for anchors
         el.classList.add(anchor.class);


### PR DESCRIPTION
## Summary
- add colour engine module for brand palette and persistence
- use colour engine in navigation, homepage and physics modules
- remember last chosen colour in session storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753323ec30832cbce0838527f2296c