### PR TITLE
Implement tilt navigation for mobile homepage

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -105,6 +105,39 @@ img {
   .home-side { font-size: 10vw; }
 }
 
+.home-highlight {
+  --base-y: -100%;
+  --parallax: 0%;
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 50%;
+  background: var(--session-colour, #FE2712);
+  transform: translateY(calc(var(--base-y) + var(--parallax)));
+  transition: transform var(--highlight-duration, 180ms) ease-out;
+  pointer-events: none;
+}
+.home-highlight--top { --base-y: 0%; }
+.home-highlight--bottom { --base-y: 100%; }
+.home-highlight--neutral { --base-y: -100%; }
+
+@media (prefers-reduced-motion: reduce) {
+  .home-highlight { transition-duration: 0ms; }
+}
+
+#tilt-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 0.4rem 0.8rem;
+  background: rgba(255,255,255,0.9);
+  border: 2px solid #000;
+  border-radius: 0.6rem;
+  font-size: 1rem;
+  pointer-events: none;
+}
+
 
 /* permission pop up */
 


### PR DESCRIPTION
## Summary
- add tilt-based highlight logic on the homepage
- style new highlight panel and tilt hint overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876241a26f8832cb030ddb13b8ebad9