### PR TITLE
Improve mobile tilt color interaction

### DIFF
--- a/src/pages/homepage.js
+++ b/src/pages/homepage.js
@@ -1,113 +1,155 @@
-
 import { requestIOSMotionPermission } from '../utils/iosPermission.js';
 import { getRandomColor, setNavHighlightColor } from '../utils/colorSystem.js';
 
-const TILT_THRESHOLD = 20; // degrees; tweak as needed
+/**
+ * Initialise tilt interaction on the home page.
+ * Calibrates on first event and updates pane background colour based on device orientation.
+ * Returns a teardown function removing the event listener.
+ */
+function initTiltHome(whoPane, whatPane) {
+  let baseBeta = null;
+  let active = 'none';
 
-function setupGyroColorSwitch(topDiv, bottomDiv, threshold = TILT_THRESHOLD) {
-  let lastTop = null, lastBottom = null;
-  let currentState = "none";
+  const handleOrientation = (e) => {
+    if (baseBeta === null) baseBeta = e.beta;
+    const dBeta = e.beta - baseBeta;
+    let newActive = 'none';
+    if (dBeta <= -8) newActive = 'who';
+    else if (dBeta >= 8) newActive = 'what';
 
-  function handleOrientation(event) {
-    const { beta } = event;
-    if (beta > threshold && currentState !== "top") {
-      const color = getRandomColor([lastTop, lastBottom]);
-      topDiv.style.background = color;
-      bottomDiv.style.background = "#fff";
-      lastTop = color;
-      currentState = "top";
-    } else if (beta < -threshold && currentState !== "bottom") {
-      const color = getRandomColor([lastBottom, lastTop]);
-      bottomDiv.style.background = color;
-      topDiv.style.background = "#fff";
-      lastBottom = color;
-      currentState = "bottom";
-    } else if (beta >= -threshold && beta <= threshold && currentState !== "none") {
-      topDiv.style.background = "#fff";
-      bottomDiv.style.background = "#fff";
-      currentState = "none";
+    if (newActive !== active) {
+      if (newActive === 'who') {
+        whoPane.style.setProperty('--pane-bkg', 'var(--session-colour)');
+        whatPane.style.setProperty('--pane-bkg', '#fff');
+      } else if (newActive === 'what') {
+        whatPane.style.setProperty('--pane-bkg', 'var(--session-colour)');
+        whoPane.style.setProperty('--pane-bkg', '#fff');
+      } else {
+        whoPane.style.setProperty('--pane-bkg', '#fff');
+        whatPane.style.setProperty('--pane-bkg', '#fff');
+      }
+      whoPane.style.setProperty('--bkg-offset', '0px');
+      whatPane.style.setProperty('--bkg-offset', '0px');
+      active = newActive;
     }
-  }
 
-  window.addEventListener("deviceorientation", handleOrientation, true);
-  return () => window.removeEventListener("deviceorientation", handleOrientation, true);
+    // micro parallax up to ±3°
+    if (active === 'who') {
+      const extra = Math.max(-3, Math.min(dBeta + 8, 3));
+      whoPane.style.setProperty('--bkg-offset', `${(extra / 3) * 10}px`);
+    } else if (active === 'what') {
+      const extra = Math.max(-3, Math.min(dBeta - 8, 3));
+      whatPane.style.setProperty('--bkg-offset', `${(extra / 3) * 10}px`);
+    }
+  };
+
+  window.addEventListener('deviceorientation', handleOrientation, true);
+  return () => window.removeEventListener('deviceorientation', handleOrientation, true);
 }
 
 export function renderHomepage(app) {
-  app.innerHTML = "";
+  app.innerHTML = '';
 
-  const container = document.createElement("div");
-  container.className = "home-split";
+  const container = document.createElement('div');
+  container.className = 'home-split';
 
-  // Top (who)
-  const whoDiv = document.createElement("div");
-  whoDiv.className = "home-side who-side";
-  whoDiv.textContent = "who?";
-  container.appendChild(whoDiv);
+  const whoPane = document.createElement('section');
+  whoPane.id = 'pane-who';
+  whoPane.className = 'home-side pane pane--top';
+  whoPane.textContent = 'who?';
 
-  // Bottom (what)
-  const whatDiv = document.createElement("div");
-  whatDiv.className = "home-side what-side";
-  whatDiv.textContent = "what?";
-  container.appendChild(whatDiv);
+  const whatPane = document.createElement('section');
+  whatPane.id = 'pane-what';
+  whatPane.className = 'home-side pane pane--bottom';
+  whatPane.textContent = 'what?';
 
+  container.appendChild(whoPane);
+  container.appendChild(whatPane);
   app.appendChild(container);
 
-  // Routing
-  whoDiv.addEventListener("click", () => {
-    if (lastWhoColor) setNavHighlightColor(lastWhoColor);
-    history.pushState({}, "", "/who");
-    window.dispatchEvent(new PopStateEvent("popstate"));
+  const root = document.documentElement;
+  const sessionColor = getRandomColor();
+  root.style.setProperty('--session-colour', sessionColor);
+
+  // routing on tap
+  whoPane.addEventListener('click', () => {
+    setNavHighlightColor(sessionColor);
+    history.pushState({}, '', '/who');
+    window.dispatchEvent(new PopStateEvent('popstate'));
   });
-  whatDiv.addEventListener("click", () => {
-    if (lastWhatColor) setNavHighlightColor(lastWhatColor);
-    history.pushState({}, "", "/what");
-    window.dispatchEvent(new PopStateEvent("popstate"));
+  whatPane.addEventListener('click', () => {
+    setNavHighlightColor(sessionColor);
+    history.pushState({}, '', '/what');
+    window.dispatchEvent(new PopStateEvent('popstate'));
   });
 
-  // Desktop hover logic
-  let lastWhoColor = null, lastWhatColor = null;
-  whoDiv.addEventListener("mouseenter", () => {
-    if (window.innerWidth > 800) {
-      const color = getRandomColor([lastWhoColor, lastWhatColor]);
-      whoDiv.style.background = color;
-      lastWhoColor = color;
+  // fallback tap-colour change if orientation not granted
+  const tapSwap = (target) => {
+    if (target === 'who') {
+      whoPane.style.setProperty('--pane-bkg', 'var(--session-colour)');
+      whatPane.style.setProperty('--pane-bkg', '#fff');
+    } else {
+      whatPane.style.setProperty('--pane-bkg', 'var(--session-colour)');
+      whoPane.style.setProperty('--pane-bkg', '#fff');
     }
-  });
-  whoDiv.addEventListener("mouseleave", () => {
-    if (window.innerWidth > 800) whoDiv.style.background = "#fff";
-  });
-  whatDiv.addEventListener("mouseenter", () => {
-    if (window.innerWidth > 800) {
-      const color = getRandomColor([lastWhatColor, lastWhoColor]);
-      whatDiv.style.background = color;
-      lastWhatColor = color;
-    }
-  });
-  whatDiv.addEventListener("mouseleave", () => {
-    if (window.innerWidth > 800) whatDiv.style.background = "#fff";
-  });
+  };
+  whoPane.addEventListener('touchstart', () => tapSwap('who'));
+  whatPane.addEventListener('touchstart', () => tapSwap('what'));
 
-  // Mobile: ask for motion permission first, then activate gyro logic
-  let teardownGyro = null;
+  let teardownTilt = null;
   if (/Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
     requestIOSMotionPermission(
-      // enableOrientationCallback:
       () => {
-        teardownGyro = setupGyroColorSwitch(whoDiv, whatDiv, TILT_THRESHOLD);
+        teardownTilt = initTiltHome(whoPane, whatPane);
       },
-      // fallbackCallback:
       () => {
-        // No gyro: maybe show a message, or just leave colors static
-        // Optionally: set both backgrounds to white for clarity
-        whoDiv.style.background = "#fff";
-        whatDiv.style.background = "#fff";
+        whoPane.style.setProperty('--pane-bkg', '#fff');
+        whatPane.style.setProperty('--pane-bkg', '#fff');
       }
     );
   }
 
+  // auto demo after idle
+  const demoTimeout = setTimeout(() => {
+    const hint = document.createElement('div');
+    hint.textContent = 'Tilt to choose';
+    hint.style.position = 'absolute';
+    hint.style.top = '50%';
+    hint.style.left = '50%';
+    hint.style.transform = 'translate(-50%, -50%)';
+    hint.style.pointerEvents = 'none';
+    app.appendChild(hint);
+
+    const seq = [
+      () => {
+        whoPane.style.setProperty('--pane-bkg', 'var(--session-colour)');
+        whatPane.style.setProperty('--pane-bkg', '#fff');
+      },
+      () => {
+        whoPane.style.setProperty('--pane-bkg', '#fff');
+        whatPane.style.setProperty('--pane-bkg', 'var(--session-colour)');
+      },
+      () => {
+        whoPane.style.setProperty('--pane-bkg', '#fff');
+        whatPane.style.setProperty('--pane-bkg', '#fff');
+        hint.remove();
+      }
+    ];
+
+    let step = 0;
+    const interval = setInterval(() => {
+      seq[step]();
+      step += 1;
+      if (step === seq.length) clearInterval(interval);
+    }, 400);
+  }, 1500);
+
+  const cancelDemo = () => clearTimeout(demoTimeout);
+  window.addEventListener('deviceorientation', cancelDemo, { once: true });
+  document.addEventListener('touchstart', cancelDemo, { once: true });
+
   return () => {
-    if (teardownGyro) teardownGyro();
-    // Any further cleanup if needed
+    if (teardownTilt) teardownTilt();
+    clearTimeout(demoTimeout);
   };
 }

--- a/src/style.css
+++ b/src/style.css
@@ -96,6 +96,21 @@ img {
   font-family: 'HelveticaRounded', sans-serif;
 }
 
+/* pane styling for tilt interaction */
+.pane {
+  background: var(--pane-bkg, #fff);
+  transition: background 180ms ease-out;
+  background-position: center var(--bkg-offset, 0);
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pane {
+    transition-duration: 0ms;
+  }
+}
+
 @media (max-width: 800px) {
     .home-split {
     flex-direction: column;

--- a/src/style.css
+++ b/src/style.css
@@ -105,6 +105,14 @@ img {
   background-size: cover;
 }
 
+.tilt-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .pane {
     transition-duration: 0ms;


### PR DESCRIPTION
## Summary
- replace homepage markup with two `<section>` elements (`pane-who` and `pane-what`)
- implement `initTiltHome` to calibrate device orientation and change each pane's `--pane-bkg` colour
- add micro-parallax and demo prompt
- add fallback tap swap and request motion permission
- style `.pane` class with CSS variables and reduced-motion support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876299efe40832c9bdc34c18ee9e459