### PR TITLE
Improve mobile tilt interaction

### DIFF
--- a/src/pages/homepage.js
+++ b/src/pages/homepage.js
@@ -2,35 +2,70 @@
 import { requestIOSMotionPermission } from '../utils/iosPermission.js';
 import { getRandomColor, setNavHighlightColor } from '../utils/colorSystem.js';
 
-const TILT_THRESHOLD = 20; // degrees; tweak as needed
+const TILT_THRESHOLD = 8; // degrees for zone changes
+const PARALLAX_RANGE = 3; // additional degrees for micro-shift
 
-function setupGyroColorSwitch(topDiv, bottomDiv, threshold = TILT_THRESHOLD) {
-  let lastTop = null, lastBottom = null;
-  let currentState = "none";
+function setupGyroColorSwitch(topDiv, bottomDiv, cancelDemo) {
+  let lastTop = null,
+    lastBottom = null,
+    baseline = null,
+    currentState = 'neutral';
+
+  // apply the snap easing once at setup
+  const transition = 'background 180ms ease-out, background-position 180ms ease-out';
+  topDiv.style.transition = transition;
+  bottomDiv.style.transition = transition;
+
+  const clearParallax = () => {
+    topDiv.style.backgroundPosition = '';
+    bottomDiv.style.backgroundPosition = '';
+  };
+
+  const applyShift = (el, diff) => {
+    const clamped = Math.max(-PARALLAX_RANGE, Math.min(PARALLAX_RANGE, diff));
+    const px = (clamped / PARALLAX_RANGE) * 15; // max ~15px shift
+    el.style.backgroundPosition = `center calc(50% + ${px}px)`;
+  };
 
   function handleOrientation(event) {
-    const { beta } = event;
-    if (beta > threshold && currentState !== "top") {
-      const color = getRandomColor([lastTop, lastBottom]);
-      topDiv.style.background = color;
-      bottomDiv.style.background = "#fff";
-      lastTop = color;
-      currentState = "top";
-    } else if (beta < -threshold && currentState !== "bottom") {
-      const color = getRandomColor([lastBottom, lastTop]);
-      bottomDiv.style.background = color;
-      topDiv.style.background = "#fff";
-      lastBottom = color;
-      currentState = "bottom";
-    } else if (beta >= -threshold && beta <= threshold && currentState !== "none") {
-      topDiv.style.background = "#fff";
-      bottomDiv.style.background = "#fff";
-      currentState = "none";
+    if (baseline === null) baseline = event.beta;
+    const beta = event.beta - baseline;
+    let nextState = 'neutral';
+    if (beta >= TILT_THRESHOLD) nextState = 'who';
+    else if (beta <= -TILT_THRESHOLD) nextState = 'what';
+
+    if (nextState !== currentState) {
+      currentState = nextState;
+      clearParallax();
+      if (currentState === 'who') {
+        const color = getRandomColor([lastTop, lastBottom]);
+        topDiv.style.background = color;
+        bottomDiv.style.background = '#fff';
+        lastTop = color;
+      } else if (currentState === 'what') {
+        const color = getRandomColor([lastBottom, lastTop]);
+        bottomDiv.style.background = color;
+        topDiv.style.background = '#fff';
+        lastBottom = color;
+      } else {
+        topDiv.style.background = '#fff';
+        bottomDiv.style.background = '#fff';
+      }
+      if (currentState !== 'neutral' && typeof cancelDemo === 'function') {
+        cancelDemo();
+      }
+    }
+
+    // micro parallax within zone
+    if (currentState === 'who') {
+      applyShift(topDiv, beta - TILT_THRESHOLD);
+    } else if (currentState === 'what') {
+      applyShift(bottomDiv, beta + TILT_THRESHOLD);
     }
   }
 
-  window.addEventListener("deviceorientation", handleOrientation, true);
-  return () => window.removeEventListener("deviceorientation", handleOrientation, true);
+  window.addEventListener('deviceorientation', handleOrientation, true);
+  return () => window.removeEventListener('deviceorientation', handleOrientation, true);
 }
 
 export function renderHomepage(app) {
@@ -53,14 +88,59 @@ export function renderHomepage(app) {
 
   app.appendChild(container);
 
+  // ------- auto demo hint -------
+  let demoTimeout;
+  let demoHint;
+  const demoSteps = [];
+
+  const cancelDemo = () => {
+    if (demoTimeout) clearTimeout(demoTimeout);
+    demoTimeout = null;
+    demoSteps.forEach(t => clearTimeout(t));
+    demoSteps.length = 0;
+    if (demoHint) {
+      demoHint.remove();
+      demoHint = null;
+    }
+  };
+
+  const startDemo = () => {
+    const topColor = getRandomColor();
+    const bottomColor = getRandomColor([topColor]);
+    demoHint = document.createElement('div');
+    demoHint.id = 'tilt-hint';
+    demoHint.textContent = 'Tilt to choose';
+    document.body.appendChild(demoHint);
+    demoSteps.push(setTimeout(() => {
+      whoDiv.style.background = topColor;
+      whatDiv.style.background = '#fff';
+    }, 50));
+    demoSteps.push(setTimeout(() => {
+      whoDiv.style.background = '#fff';
+      whatDiv.style.background = bottomColor;
+    }, 350));
+    demoSteps.push(setTimeout(() => {
+      whoDiv.style.background = '#fff';
+      whatDiv.style.background = '#fff';
+    }, 650));
+  };
+
+  demoTimeout = setTimeout(startDemo, 2000);
+
+  // dismiss hint on tap
+  container.addEventListener('touchstart', cancelDemo, { once: false });
+  container.addEventListener('mousedown', cancelDemo, { once: false });
+
   // Routing
   whoDiv.addEventListener("click", () => {
     if (lastWhoColor) setNavHighlightColor(lastWhoColor);
+    cancelDemo();
     history.pushState({}, "", "/who");
     window.dispatchEvent(new PopStateEvent("popstate"));
   });
   whatDiv.addEventListener("click", () => {
     if (lastWhatColor) setNavHighlightColor(lastWhatColor);
+    cancelDemo();
     history.pushState({}, "", "/what");
     window.dispatchEvent(new PopStateEvent("popstate"));
   });
@@ -94,7 +174,7 @@ export function renderHomepage(app) {
     requestIOSMotionPermission(
       // enableOrientationCallback:
       () => {
-        teardownGyro = setupGyroColorSwitch(whoDiv, whatDiv, TILT_THRESHOLD);
+        teardownGyro = setupGyroColorSwitch(whoDiv, whatDiv, cancelDemo);
       },
       // fallbackCallback:
       () => {
@@ -102,6 +182,7 @@ export function renderHomepage(app) {
         // Optionally: set both backgrounds to white for clarity
         whoDiv.style.background = "#fff";
         whatDiv.style.background = "#fff";
+        cancelDemo();
       }
     );
   }

--- a/src/style.css
+++ b/src/style.css
@@ -91,9 +91,23 @@ img {
   cursor: pointer;
   background: #fff;
   color: #000;
-  transition: background 0.18s;
+  transition: background 0.18s, background-position 0.18s;
   user-select: none;
   font-family: 'HelveticaRounded', sans-serif;
+}
+
+#tilt-hint {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid #000;
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  z-index: 1000;
+  pointer-events: none;
 }
 
 @media (max-width: 800px) {


### PR DESCRIPTION
## Summary
- tweak mobile tilt control with baseline logic and parallax shift
- add hint demo that runs if the user is idle on the homepage
- style hint element and support background-position transition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68762dabc244832cb3b1ab3fd26e69ad