### PR TITLE
Update cursor mappings

### DIFF
--- a/public/cursors/drag.svg
+++ b/public/cursors/drag.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="32px" height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+        width="64px" height="64px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g>
 	<g>
 		<g>

--- a/public/cursors/normal.svg
+++ b/public/cursors/normal.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="32px" height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+        width="64px" height="64px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g>
 	<g>
 		<path d="M10.9,24.97c0-0.17-1.84-0.47-2.23-0.6c-0.81-0.29-1.58-0.72-2.27-1.24c-1.43-1.07-2.57-2.58-3.16-4.27

--- a/public/cursors/point.svg
+++ b/public/cursors/point.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="32px" height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+        width="64px" height="64px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <text transform="matrix(1 0 0 1 -972.9856 -43.7528)"><tspan x="0" y="0" font-family="'HelveticaRounded-Bold'" font-size="72px" letter-spacing="-1">just</tspan><tspan x="-12.46" y="55" font-family="'HelveticaRounded-Bold'" font-size="72px" letter-spacing="-1">click</tspan></text>
 <path fill="none" stroke="#000000" stroke-width="5" stroke-miterlimit="10" d="M-853.83,52.26h-111.05
 	c-22.82,0-41.33-18.5-41.33-41.33v-97.35c0-22.82,18.5-41.33,41.33-41.33h111.05c22.82,0,41.33,18.5,41.33,41.33v97.35

--- a/src/style.css
+++ b/src/style.css
@@ -22,6 +22,7 @@ html, body {
   min-height: 100%;
   overflow: auto;
   font-display: swap;
+  cursor: url('/cursors/normal.svg') 32 32, auto;
 }
 
 img {
@@ -88,7 +89,6 @@ img {
   justify-content: center;
   align-items: center;
   font-size: 6vw;
-  cursor: pointer;
   background: #fff;
   color: #000;
   transition: background 0.18s;
@@ -160,7 +160,6 @@ img {
   border-width: 3px;
   border-style: solid;
   border-radius: 1rem;
-  cursor: pointer;
   margin: .3rem;
 }
 
@@ -217,7 +216,6 @@ img {
   border: 4px solid #000;     /* thick black outline */
   border-radius: 18px;        /* same radius family */
   box-shadow: 4px 4px 0 #000; /* offset shadow: right + bottom only */
-  cursor: pointer;
 }
 .view-full-project-button:hover {
   transform: translate(-2px, -2px);       /* subtle lift */
@@ -409,7 +407,6 @@ img {
   color: #000000;
   border: 3px solid #000;
   box-shadow: 2px 2px 0 #000;
-  cursor: pointer;
   border-radius: 10px;
   transition: transform .15s, box-shadow .15s;
 
@@ -499,7 +496,6 @@ img {
   pointer-events: auto;
   user-select: none;
   text-align: center;
-  cursor: pointer;
   white-space: pre-line; /* ESSENTIAL for \n to work */
   /* Optional: text-shadow for contrast */
 }
@@ -516,7 +512,7 @@ img {
   color: #181818;
   font-size: 1rem;
   font-family: inherit;
-  cursor: grab;
+  /* cursor updated below */
   z-index: 10;
   user-select: none;
   /* Drag friendliness */
@@ -524,9 +520,6 @@ img {
   z-index: 1000;
 }
 
-.microtext:active {
-  cursor: grabbing;
-}
 
 /* For links */
 .microtext.link {
@@ -535,7 +528,6 @@ img {
   color: #000000;
   border: 3px solid #000;
   box-shadow: 2px 2px 0 #000;
-  cursor: pointer;
   border-radius: 14px;
 }
 .microtext.link:hover {
@@ -546,6 +538,33 @@ img {
   transform: translate(0,0);
   box-shadow: 2px 2px 0 #000;
 }
+
+/* --- Custom Cursors ----------------------------------------------------- */
+.home-side,
+.nav-button,
+.what-nav-button,
+.modal-close-button,
+.view-full-project-button,
+.project-video,
+.full-project-video,
+.anchor:not(#contact),
+.microtext.link {
+  cursor: url('/cursors/point.svg') 32 32, auto;
+}
+
+#contact {
+  cursor: url('/cursors/contacts.svg') 32 32, auto;
+}
+
+.microtext {
+  cursor: url('/cursors/normal.svg') 32 32, auto;
+}
+
+.microtext:active,
+.microtext.link:active {
+  cursor: url('/cursors/drag.svg') 32 32, auto;
+}
+
 
 /* Example for custom class, e.g. .special (optional) */
 .microtext.special {

--- a/src/utils/navButtons.js
+++ b/src/utils/navButtons.js
@@ -56,7 +56,6 @@ export function createPhysicsNavMenu(world, container, currentPage) {
     el.textContent = btn.label;
     el.className = 'nav-button';
     el.style.position = 'absolute';
-    el.style.cursor = 'pointer';
     el.style.fontFamily = 'inherit';
     el.style.userSelect = 'none';
     el.style.background = 'transparent';

--- a/src/utils/physicsSetup.js
+++ b/src/utils/physicsSetup.js
@@ -63,6 +63,15 @@ export function enableDragging(engine, world, container) {
   });
   Matter.World.add(world, mouseConstraint);
 
+  const handleStartDrag = () => {
+    document.body.style.cursor = "url('/cursors/drag.svg') 32 32, auto";
+  };
+  const handleEndDrag = () => {
+    document.body.style.cursor = '';
+  };
+  Matter.Events.on(mouseConstraint, 'startdrag', handleStartDrag);
+  Matter.Events.on(mouseConstraint, 'enddrag', handleEndDrag);
+
   // Custom mobile-friendly tap/drag detection
   let isDragging = false;
   let dragStart = { x: 0, y: 0 };
@@ -103,6 +112,8 @@ export function enableDragging(engine, world, container) {
     container.removeEventListener('touchstart', handleTouchStart);
     container.removeEventListener('touchmove', handleTouchMove);
     container.removeEventListener('touchend', handleTouchEnd);
+    Matter.Events.off(mouseConstraint, 'startdrag', handleStartDrag);
+    Matter.Events.off(mouseConstraint, 'enddrag', handleEndDrag);
   };
 }
 

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -79,12 +79,22 @@ export function setupWhatPhysics() {
   container.id = 'container';
   container.classList.add('container');
   container.style.touchAction = 'none'; // Crucial for custom pointer/touch handling
+  container.style.cursor = "url('/cursors/just-click.svg') 32 32, auto";
   document.body.appendChild(container);
 
   // --- Step 5: Project Data and State ---
   const projects = projectsData.projects;
   let currentProjectIndex = 0;
   let currentElementIndex = 0;
+
+  function updateWhitespaceCursor() {
+    const summaryElements = projects[currentProjectIndex].summary.elements;
+    if (currentElementIndex < summaryElements.length) {
+      container.style.cursor = "url('/cursors/just-click.svg') 32 32, auto";
+    } else {
+      container.style.cursor = "url('/cursors/next.svg') 32 32, auto";
+    }
+  }
 
   const amIMobile = isMobile(); // Determine device type once
 
@@ -96,6 +106,8 @@ export function setupWhatPhysics() {
     { tag: 'h1', className: 'whatpage-title' }
   );
   bodies.push({ body: titleBody, domElement: titleDom });
+
+  updateWhitespaceCursor();
 
   // Position the title: center on desktop, lower on mobile
   Matter.Body.setPosition(
@@ -341,6 +353,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       const elementData = summaryElements[currentElementIndex];
       await addProjectElement(elementData, x, y);
       currentElementIndex++;
+      updateWhitespaceCursor();
       if (currentElementIndex === summaryElements.length) {
         const buttonData = { type: 'button', content: 'View Full Project' };
         await addProjectElement(buttonData, x + (Math.random()*40-20), y + (Math.random()*40-20)); // Slight offset
@@ -354,6 +367,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       currentProjectIndex = (currentProjectIndex + 1) % projects.length;
       currentElementIndex = 0;
       clearProjectElements(); // Clears only summary items, not title/nav
+      updateWhitespaceCursor();
 
       // Remove old title
       Matter.World.remove(world, titleBody);
@@ -413,6 +427,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     currentProjectIndex = newIndex;
     currentElementIndex = 0;
     clearProjectElements();
+    updateWhitespaceCursor();
 
     // Remove old title
     Matter.World.remove(world, titleBody);


### PR DESCRIPTION
## Summary
- double size of key cursor images
- style sitewide cursor and add hover cursors for interactive elements
- manage drag cursor state when dragging Matter.js bodies
- swap cursors on the What page depending on progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878c9d311a0832cae5bb7ed5efd13e4