### PR TITLE
Disable drag ghost on ragdoll pieces

### DIFF
--- a/src/utils/whoPhysics.js
+++ b/src/utils/whoPhysics.js
@@ -236,6 +236,19 @@ function addRagdoll(world, container, bodies, currentlyIsMobile) {
     rightUpperLegData,
     rightLowerLegData,
   ]) => {
+    // Ensure ragdoll pieces don't show the browser drag ghost
+    [
+      headData,
+      torsoData,
+      leftUpperArmData,
+      leftLowerArmData,
+      rightUpperArmData,
+      rightLowerArmData,
+      leftUpperLegData,
+      leftLowerLegData,
+      rightUpperLegData,
+      rightLowerLegData,
+    ].forEach(p => p.element.setAttribute('draggable', 'false'));
     // Basic dimensions
     const headRadius = (headData.width * scale) / 2;
     const torsoW = torsoData.width;


### PR DESCRIPTION
## Summary
- make ragdoll image pieces non-draggable so the browser does not display a drag preview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f93eb614832c8195db32c8d2dee9