### PR TITLE
Add cleanup for modal videos

### DIFF
--- a/src/utils/fullProjectModal.js
+++ b/src/utils/fullProjectModal.js
@@ -10,6 +10,9 @@ export function openFullProjectModal(projectDetails) {
   const modalOverlay = document.createElement('div');
   modalOverlay.classList.add('full-project-modal-overlay');
 
+  const videoCleanups = [];
+  modalOverlay.videoCleanups = videoCleanups;
+
   // Create the modal container (grid container).
   const modalContainer = document.createElement('div');
   modalContainer.classList.add('modal-container');
@@ -19,6 +22,7 @@ export function openFullProjectModal(projectDetails) {
   closeButton.textContent = 'close';
   closeButton.classList.add('modal-close-button');
   closeButton.addEventListener('click', () => {
+    videoCleanups.forEach((fn) => fn());
     closeFullProjectModal(modalOverlay);
   });
   modalContainer.appendChild(closeButton);
@@ -33,6 +37,10 @@ export function openFullProjectModal(projectDetails) {
       }
       section.elements.forEach((item) => {
         const itemEl = createFullProjectElement(item);
+        if (item.type === 'video') {
+          const cleanup = setupVideoPlayback(itemEl);
+          videoCleanups.push(cleanup);
+        }
         sectionEl.appendChild(itemEl);
       });
       modalContainer.appendChild(sectionEl);
@@ -40,6 +48,10 @@ export function openFullProjectModal(projectDetails) {
   } else if (projectDetails.elements && Array.isArray(projectDetails.elements)) {
     projectDetails.elements.forEach((item) => {
       const itemEl = createFullProjectElement(item);
+      if (item.type === 'video') {
+        const cleanup = setupVideoPlayback(itemEl);
+        videoCleanups.push(cleanup);
+      }
       modalContainer.appendChild(itemEl);
     });
   }
@@ -82,7 +94,6 @@ function createFullProjectElement(item) {
       el.src = item.src;
       el.controls = true;
       el.classList.add('full-project-video');
-      setupVideoPlayback(el);
       break;
     default:
       el = document.createElement('div');

--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -88,6 +88,9 @@ export function setupVideoPlayback(video) {
     });
   });
   observer.observe(video);
+  return () => {
+    observer.disconnect();
+  };
 }
 
 


### PR DESCRIPTION
## Summary
- return a cleanup function from `setupVideoPlayback`
- clean up IntersectionObservers for modal videos when the modal closes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879012d0efc832ca4bec299143377b1