### PR TITLE
Avoid repeated tilt permission prompts

### DIFF
--- a/src/pages/homepage.js
+++ b/src/pages/homepage.js
@@ -197,15 +197,33 @@ export function renderHomepage(app) {
 
   let teardownTilt = null;
   if (/Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
-    requestIOSMotionPermission(
-      () => {
-        teardownTilt = initTiltHome(whoPane, whatPane, app, tapSwap);
-      },
-      () => {
-        whoPane.style.setProperty('--pane-bkg', '#fff');
-        whatPane.style.setProperty('--pane-bkg', '#fff');
-      }
-    );
+    const userPreference = localStorage.getItem('gravity-mode');
+
+    const enableTilt = () => {
+      teardownTilt = initTiltHome(whoPane, whatPane, app, tapSwap);
+    };
+
+    const disableTilt = () => {
+      whoPane.style.setProperty('--pane-bkg', '#fff');
+      whatPane.style.setProperty('--pane-bkg', '#fff');
+    };
+
+    if (userPreference === 'orientation') {
+      enableTilt();
+    } else if (userPreference === 'normal') {
+      disableTilt();
+    } else {
+      requestIOSMotionPermission(
+        () => {
+          localStorage.setItem('gravity-mode', 'orientation');
+          enableTilt();
+        },
+        () => {
+          localStorage.setItem('gravity-mode', 'normal');
+          disableTilt();
+        }
+      );
+    }
   }
 
   return () => {


### PR DESCRIPTION
## Summary
- store device orientation permission preference in `localStorage`
- check preference on the homepage so the orientation prompt only shows once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b3458d9a4832cb15869e7a465a6f6