### PR TITLE
Fix what page image/video flash

### DIFF
--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -101,6 +101,7 @@ export function loadAndMeasureImage(src, container, scale = 1) {
     const img = document.createElement('img');
     img.src = src;
     img.style.position = 'absolute';
+    img.style.visibility = 'hidden';
     container.appendChild(img);
     img.addEventListener('load', () => {
       // Get natural dimensions
@@ -126,6 +127,7 @@ export function loadAndMeasureVideo(src, container, scale = 1) {
     const video = document.createElement('video');
     video.src = src;
     video.style.position = 'absolute';
+    video.style.visibility = 'hidden';
     video.controls = true;
     container.appendChild(video);
     // Set up interactive playback behaviour

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -255,6 +255,11 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     const item = { body, domElement };
     if (ro) item.ro = ro;
     bodies.push(item);
+
+    // Reveal the element after the physics body is in place
+    requestAnimationFrame(() => {
+      domElement.style.visibility = 'visible';
+    });
   }
 
   // --- Step 8: `clearProjectElements` Function ---


### PR DESCRIPTION
## Summary
- hide images and videos until loaded and bodies are positioned
- reveal DOM elements after adding bodies in `whatPhysics`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b41b739c4832c873769d320f48150