### PR TITLE
Fix asset paths for relative deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   </main>
 
   <!-- Vite injects JS scripts automatically in development and build -->
-  <script type="module" src="/src/main.js"></script>
+  <script type="module" src="./src/main.js"></script>
 </body>
 </html>
 

--- a/src/style.css
+++ b/src/style.css
@@ -3,8 +3,8 @@
    ========================================================================== */
 @font-face {
   font-family: 'HelveticaRounded';
-  src: url('/assets/font1/HelveticaRoundedLTStd-Bd.woff2') format('woff2'),
-       url('/assets/font1/HelveticaRoundedLTStd-Bd.woff') format('woff');
+  src: url('./assets/font1/HelveticaRoundedLTStd-Bd.woff2') format('woff2'),
+       url('./assets/font1/HelveticaRoundedLTStd-Bd.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }
@@ -22,7 +22,7 @@ html, body {
   min-height: 100%;
   overflow: auto;
   font-display: swap;
-  cursor: url('/cursors/normal.svg') 32 32, auto;
+  cursor: url('./cursors/normal.svg') 32 32, auto;
 }
 
 img {
@@ -584,15 +584,15 @@ img {
 .full-project-video,
 .anchor:not(#contact),
 .microtext.link {
-  cursor: url('/cursors/point.svg') 32 32, auto;
+  cursor: url('./cursors/point.svg') 32 32, auto;
 }
 
 #contact {
-  cursor: url('/cursors/contacts.svg') 32 32, auto;
+  cursor: url('./cursors/contacts.svg') 32 32, auto;
 }
 
 .microtext {
-  cursor: url('/cursors/normal.svg') 32 32, auto;
+  cursor: url('./cursors/normal.svg') 32 32, auto;
 }
 
 .whatpage-title,
@@ -605,17 +605,17 @@ img {
 .summary-xs,
 .summary-sm,
 .summary-lg {
-  cursor: url('/cursors/normal.svg') 32 32, auto;
+  cursor: url('./cursors/normal.svg') 32 32, auto;
 }
 
 .microtext:active,
 .microtext.link:active {
-  cursor: url('/cursors/drag.svg') 32 32, auto;
+  cursor: url('./cursors/drag.svg') 32 32, auto;
 }
 
 body.dragging,
 body.dragging * {
-  cursor: url('/cursors/drag.svg') 32 32, auto !important;
+  cursor: url('./cursors/drag.svg') 32 32, auto !important;
 }
 
 

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -79,7 +79,7 @@ export function setupWhatPhysics() {
   container.id = 'container';
   container.classList.add('container');
   container.style.touchAction = 'none'; // Crucial for custom pointer/touch handling
-  container.style.cursor = "url('/cursors/just-click.svg') 32 32, auto";
+  container.style.cursor = `url('${import.meta.env.BASE_URL}cursors/just-click.svg') 32 32, auto`;
   document.body.appendChild(container);
 
   // --- Step 5: Project Data and State ---
@@ -91,9 +91,9 @@ export function setupWhatPhysics() {
   function updateWhitespaceCursor() {
     const summaryElements = projects[currentProjectIndex].summary.elements;
     if (currentElementIndex < summaryElements.length) {
-      container.style.cursor = "url('/cursors/just-click.svg') 32 32, auto";
+      container.style.cursor = `url('${import.meta.env.BASE_URL}cursors/just-click.svg') 32 32, auto`;
     } else {
-      container.style.cursor = "url('/cursors/next.svg') 32 32, auto";
+      container.style.cursor = `url('${import.meta.env.BASE_URL}cursors/next.svg') 32 32, auto`;
     }
   }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,9 @@
 // vite.config.js
 export default {
-    server: {
-      host: true,
-      port: 5173, // optional, can be changed
-    },
-  };
+  base: './',
+  server: {
+    host: true,
+    port: 5173, // optional, can be changed
+  },
+};
   


### PR DESCRIPTION
## Summary
- set `base: './'` in Vite config
- use a relative script path in `index.html`
- update CSS asset URLs to be relative
- reference cursor icons with `import.meta.env.BASE_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688793114870832caab29b42f1e844af