### PR TITLE
Prefetch summary assets on initialization

### DIFF
--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -208,3 +208,22 @@ export function prefetchProjectAssets(projectDetails) {
     }
   });
 }
+
+export function prefetchSummaryAssets(summary) {
+  if (!summary || !Array.isArray(summary.elements)) return;
+
+  summary.elements.forEach((item) => {
+    if (!item.src) return;
+    const ext = item.src.split('.').pop().toLowerCase();
+    if (item.type === 'video' || ['mp4', 'webm', 'ogg', 'mov'].includes(ext)) {
+      const link = document.createElement('link');
+      link.rel = 'preload';
+      link.as = 'video';
+      link.href = item.src;
+      document.head.appendChild(link);
+    } else if (item.type === 'image') {
+      const img = new Image();
+      img.src = item.src;
+    }
+  });
+}

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -18,7 +18,8 @@ import {
   measureTextDimensionsAfterFonts,
   loadAndMeasureImage,
   loadAndMeasureVideo,
-  prefetchProjectAssets
+  prefetchProjectAssets,
+  prefetchSummaryAssets
 } from './generalUtils.js';
 import { createPhysicsNavMenu, pickRandomPrimary } from './navButtons.js';
 import { createWhatProjectNav } from './whatNav.js'; // Ensure class name 'what-nav-button' is used by this
@@ -85,6 +86,14 @@ export function setupWhatPhysics() {
 
   // --- Step 5: Project Data and State ---
   const projects = projectsData.projects;
+  projects.forEach((p, i) => {
+    const fn = () => prefetchSummaryAssets(p.summary);
+    if (window.requestIdleCallback) {
+      requestIdleCallback(fn);
+    } else {
+      setTimeout(fn, i * 50);
+    }
+  });
   let currentProjectIndex = 0;
   let currentElementIndex = 0;
   let holdButtonDom = null;


### PR DESCRIPTION
## Summary
- preload summary assets for all projects on initialization
- expose a `prefetchSummaryAssets` helper
- use `requestIdleCallback` or a timeout when prefetching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887d7a41f6c832c9f19d3721d5b19f6