### PR TITLE
Improve asset loading for whatpage

### DIFF
--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -138,6 +138,9 @@ export function loadAndMeasureVideo(src, container, scale = 1) {
     // metadata loads and sizing/positioning occur.
     video.style.visibility = 'hidden';
     video.controls = true;
+    video.autoplay = true;
+    video.muted = true;
+    video.playsInline = true;
     container.appendChild(video);
     // Set up interactive playback behaviour
     setupVideoPlayback(video);
@@ -159,6 +162,10 @@ export function loadAndMeasureVideo(src, container, scale = 1) {
       const measuredW = video.offsetWidth;
       const measuredH = video.offsetHeight;
       video.style.visibility = 'visible';
+      // Start playback once metadata is available
+      video.play().catch(() => {
+        /* ignore autoplay failures */
+      });
       resolve({ element: video, width: measuredW, height: measuredH });
     });
     

--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -99,6 +99,7 @@ export function setupVideoPlayback(video) {
 export function loadAndMeasureImage(src, container, scale = 1, alt = '') {
   return new Promise((resolve, reject) => {
     const img = document.createElement('img');
+    img.loading = 'lazy';
     img.src = src;
     if (alt) {
       img.alt = alt;

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -86,14 +86,19 @@ export function setupWhatPhysics() {
 
   // --- Step 5: Project Data and State ---
   const projects = projectsData.projects;
-  projects.forEach((p, i) => {
-    const fn = () => prefetchSummaryAssets(p.summary);
-    if (window.requestIdleCallback) {
-      requestIdleCallback(fn);
-    } else {
-      setTimeout(fn, i * 50);
+  const summaryPrefetched = new Set();
+  const preloadSummary = (index) => {
+    if (!summaryPrefetched.has(index)) {
+      summaryPrefetched.add(index);
+      const fn = () => prefetchSummaryAssets(projects[index].summary);
+      if (window.requestIdleCallback) {
+        requestIdleCallback(fn);
+      } else {
+        setTimeout(fn, 50 * index);
+      }
     }
-  });
+  };
+  preloadSummary(0);
   let currentProjectIndex = 0;
   let currentElementIndex = 0;
   let holdButtonDom = null;
@@ -124,6 +129,9 @@ export function setupWhatPhysics() {
     preloadedIndices.add(currentProjectIndex);
     prefetchProjectAssets(projects[currentProjectIndex].details);
   }
+  // Prefetch the next project's summary to keep one step ahead
+  const nextSummaryIndex = (currentProjectIndex + 1) % projects.length;
+  preloadSummary(nextSummaryIndex);
 
   updateWhitespaceCursor();
 
@@ -531,6 +539,15 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     if (!preloadedIndices.has(currentProjectIndex)) {
       preloadedIndices.add(currentProjectIndex);
       prefetchProjectAssets(projects[currentProjectIndex].details);
+    }
+    preloadSummary(currentProjectIndex);
+
+    // Preload the next project's summary and details
+    const nextIndex = (currentProjectIndex + 1) % projects.length;
+    preloadSummary(nextIndex);
+    if (!preloadedIndices.has(nextIndex)) {
+      preloadedIndices.add(nextIndex);
+      prefetchProjectAssets(projects[nextIndex].details);
     }
 
     // Remove old title


### PR DESCRIPTION
## Summary
- lazily load images in `loadAndMeasureImage`
- prefetch only the current and next project summaries
- prefetch next project details only when needed

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887e10deb30832c9f80fca55ce2b0b1