### PR TITLE
Enable looping for summary videos

### DIFF
--- a/src/utils/generalUtils.js
+++ b/src/utils/generalUtils.js
@@ -141,6 +141,7 @@ export function loadAndMeasureVideo(src, container, scale = 1) {
     video.autoplay = true;
     video.muted = true;
     video.playsInline = true;
+    video.loop = true;
     container.appendChild(video);
     // Set up interactive playback behaviour
     setupVideoPlayback(video);


### PR DESCRIPTION
## Summary
- ensure video elements created in `loadAndMeasureVideo` loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68889d440f54832ca80fbf207a13efe2