### PR TITLE
Fix iOS orientation permission on homepage

### DIFF
--- a/src/pages/homepage.js
+++ b/src/pages/homepage.js
@@ -199,13 +199,34 @@ export function renderHomepage(app) {
   if (/Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
     const userPreference = localStorage.getItem('gravity-mode');
 
-    const enableTilt = () => {
-      teardownTilt = initTiltHome(whoPane, whatPane, app, tapSwap);
-    };
-
     const disableTilt = () => {
       whoPane.style.setProperty('--pane-bkg', '#fff');
       whatPane.style.setProperty('--pane-bkg', '#fff');
+    };
+
+    const enableTilt = () => {
+      const startTilt = () => {
+        teardownTilt = initTiltHome(whoPane, whatPane, app, tapSwap);
+      };
+
+      if (
+        typeof DeviceOrientationEvent !== 'undefined' &&
+        typeof DeviceOrientationEvent.requestPermission === 'function'
+      ) {
+        DeviceOrientationEvent.requestPermission()
+          .then(state => {
+            if (state === 'granted') {
+              startTilt();
+            } else {
+              disableTilt();
+            }
+          })
+          .catch(() => {
+            disableTilt();
+          });
+      } else {
+        startTilt();
+      }
     };
 
     if (userPreference === 'orientation') {


### PR DESCRIPTION
## Summary
- request `DeviceOrientationEvent` permission on the homepage before enabling tilt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f5076f5c832ca31e5d861627ad44