### PR TITLE
feat: add mobile tap hint on what page

### DIFF
--- a/src/pages/whatpage.js
+++ b/src/pages/whatpage.js
@@ -28,7 +28,7 @@ export function renderWhatpage(app) {
       document.body.appendChild(nudgeEl);
       window.addEventListener('touchstart', removeNudge);
       nudgeRemoveTimeoutId = setTimeout(removeNudge, 4000);
-    }, 2000);
+    }, 1000);
   }
 
   // Return the teardown function so that the router can call it when leaving this page.

--- a/src/style.css
+++ b/src/style.css
@@ -205,14 +205,21 @@ img {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: #fff;
+  background: rgba(255, 255, 255, 0.8);
   color: #000;
   padding: 0.5rem 1rem;
-  border: 3px solid #000;
-  border-radius: 12px;
   z-index: 1000;
   pointer-events: none;
   font-size: 1rem;
+  opacity: 0;
+  animation: tap-nudge-fade 4s ease-in-out forwards;
+}
+
+@keyframes tap-nudge-fade {
+  0% { opacity: 0; }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 


### PR DESCRIPTION
## Summary
- show temporary "tap the empty space" hint on mobile when visiting the what page
- add styling for centered tap hint overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689484aa0e74832cac4803642adc95c8