### PR TITLE
Make mobile nav text responsive

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -664,7 +664,7 @@ body.dragging * {
     font-size: 1.8rem; /* Or whatever looks good */
   }
   .anchor-big {
-    font-size: 1.7rem; /* Example */
+    font-size: clamp(1.2rem, 6vw, 1.7rem);
   }
   #main-name {
     text-align: left;
@@ -673,12 +673,12 @@ body.dragging * {
     text-align: right;
   }
   .anchor-small {
-    font-size: .8rem;   /* Example */
+    font-size: clamp(0.6rem, 3vw, 0.8rem);
   }
   .microtext {
     font-size: 0.85rem; /* Example */
     /* Consider a max-width for microtexts on mobile too */
-    max-width: 30vw; /* Or a pixel value that works */
+    max-width: min(240px, 60vw);
   }
 }
 


### PR DESCRIPTION
## Summary
- use `clamp()` for `.anchor-big`/`.anchor-small` mobile font sizes so text scales on small screens
- widen mobile `.microtext` with `min(240px,60vw)` max width

## Testing
- `npm test`
- `npx playwright@1.41.1 install chromium` *(fails: npm error canceled)*
- `chromium-browser --headless --no-sandbox --disable-gpu --window-size=375,812 --screenshot=screen375.png index.html` *(fails: snap not installed)*
- `wkhtmltoimage --width 375 index.html screen375.png` *(fails: ProtocolUnknownError)*


------
https://chatgpt.com/codex/tasks/task_e_6894895dc02c832c8be999a1eaf06256