### PR TITLE
Handle extra-small screen anchor positions

### DIFF
--- a/src/data/who_text.js
+++ b/src/data/who_text.js
@@ -6,7 +6,8 @@ export const ANCHORS = [
     text: "i'm gianpaolo\nbormioli",
     position: {
       desktop: { x: 0.42, y: 0.45 }, // edit as you wish, 0.5 = centered
-      mobile:  { x: 0.25, y: 0.42 }
+      mobile:  { x: 0.25, y: 0.42 },
+      xs:      { x: 0.5,  y: 0.34 }
     },
     size: "big",
     microTexts: [
@@ -18,7 +19,8 @@ export const ANCHORS = [
     text: "what\nabout you?",
     position: {
       desktop: { x: 0.62, y: 0.55 },
-      mobile:  { x: 0.8, y: 0.52 }
+      mobile:  { x: 0.8,  y: 0.52 },
+      xs:      { x: 0.5,  y: 0.67 }
     },
     size: "big",
     microTexts: [
@@ -31,7 +33,8 @@ export const ANCHORS = [
     text: "anti-nothing approach",
     position: {
       desktop: { x: 0.14, y: 0.2 },
-      mobile:  { x: 0.7, y: 0.8 }
+      mobile:  { x: 0.7,  y: 0.8 },
+      xs:      { x: 0.83, y: 0.82 }
     },
     size: "small",
     microTexts: [
@@ -45,7 +48,8 @@ export const ANCHORS = [
     text: "a communication designer",
     position: {
       desktop: { x: 0.785, y: 0.3 },
-      mobile:  { x: 0.3, y: 0.17 }
+      mobile:  { x: 0.3,   y: 0.17 },
+      xs:      { x: 0.2,   y: 0.2 }
     },
     size: "small",
     microTexts: [
@@ -58,7 +62,8 @@ export const ANCHORS = [
     text: "i do stuff",
     position: {
       desktop: { x: 0.2, y: 0.7 },
-      mobile:  { x: 0.7, y: 0.3 }
+      mobile:  { x: 0.7, y: 0.3 },
+      xs:      { x: 0.85, y: 0.15 }
     },
     size: "small",
     microTexts: [
@@ -72,7 +77,8 @@ export const ANCHORS = [
     text: "creative direction / storytelling",
     position: {
       desktop: { x: 0.7, y: 0.8 },
-      mobile:  { x: 0.3, y: 0.67 }
+      mobile:  { x: 0.3,  y: 0.67 },
+      xs:      { x: 0.2,  y: 0.85 }
     },
     size: "small",
     microTexts: [

--- a/src/utils/whoPhysics.js
+++ b/src/utils/whoPhysics.js
@@ -32,10 +32,15 @@ import rightLowerLegPath from '../assets/who/rightLowerLeg.png';
 
 // --- Helper: Get anchor position (fractional, supports dx/dy pixel nudge) ---
 function getAnchorPosition(anchor, isOnMobile) {
-  const mode = isOnMobile ? "mobile" : "desktop";
-  const pos = anchor.position[mode];
-  const dx = pos && "dx" in pos ? pos.dx : 0;
-  const dy = pos && "dy" in pos ? pos.dy : 0;
+  let mode;
+  if (window.innerWidth <= 400 && anchor.position.xs) {
+    mode = 'xs';
+  } else {
+    mode = isOnMobile ? 'mobile' : 'desktop';
+  }
+  const pos = anchor.position[mode] || anchor.position.desktop;
+  const dx = pos && 'dx' in pos ? pos.dx : 0;
+  const dy = pos && 'dy' in pos ? pos.dy : 0;
   return {
     x: Math.round((pos.x || 0) * window.innerWidth + dx),
     y: Math.round((pos.y || 0) * window.innerHeight + dy),


### PR DESCRIPTION
## Summary
- add `xs` coordinate sets for who page anchors on screens under 400px
- update physics helper to pick `xs` layout when window width is small

## Testing
- `npm test`
- `node` script to verify anchor boxes don't overlap at iPhone X dimensions


------
https://chatgpt.com/codex/tasks/task_e_6894896f4d00832cb9bdb1801abc9851