### PR TITLE
Move title hint styles to CSS

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -184,6 +184,26 @@ img {
   max-width: 70vw;  /* mobile-friendly width */
 }
 
+#title-click-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.95);
+  color: #000;
+  font-size: 1rem;
+  z-index: 1000;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+@media (min-width: 769px) {
+  #title-click-hint {
+    top: 40%;
+  }
+}
+
 .project-element {
   position: absolute;
   top: 0;

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -144,7 +144,9 @@ export function setupWhatPhysics() {
     if (!hint) {
       hint = document.createElement('div');
       hint.id = id;
-      hint.textContent = "dont click the title but the white space...";
+      hint.textContent = amIMobile
+        ? "dont tap the title but the white space..."
+        : "dont click the title but the white space...";
       container.appendChild(hint);
       // Force reflow to enable fade-in transition
       // eslint-disable-next-line no-unused-expressions

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -145,22 +145,6 @@ export function setupWhatPhysics() {
       hint = document.createElement('div');
       hint.id = id;
       hint.textContent = "dont click the title but the white space...";
-      // Centered overlay styling (kept local to avoid CSS changes)
-      hint.style.position = 'absolute';
-      hint.style.top = '50%';
-      hint.style.left = '50%';
-      hint.style.transform = 'translate(-50%, -50%)';
-      hint.style.background = 'rgba(255,255,255,0.95)';
-      hint.style.color = '#000';
-      hint.style.border = '3px solid #000';
-      hint.style.borderRadius = '16px';
-      hint.style.boxShadow = '4px 4px 0 #000';
-      hint.style.padding = '0.6rem 0.9rem';
-      hint.style.fontSize = '1rem';
-      hint.style.zIndex = '1000';
-      hint.style.pointerEvents = 'none';
-      hint.style.opacity = '0';
-      hint.style.transition = 'opacity 120ms ease';
       container.appendChild(hint);
       // Force reflow to enable fade-in transition
       // eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
## Summary
- move `#title-click-hint` styling from JS to CSS
- strip button-like padding, border, and box shadow
- position hint higher on desktop (~40% from top)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c017539a4c832cbefcba5ec3f834ea