### PR TITLE
Add project list dropdown to what page nav

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -70,9 +70,9 @@ img {
   left: 0;
   transform: translateX(-50%);
   background: #fff;
-  border: 1px solid #000;
+  border: 4px solid #000;
   border-radius: 12px;
-  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.16);
+  box-shadow: 6px 6px 0 #000;
   padding: 0.5rem 0;
   max-height: min(70vh, 420px);
   max-width: min(90vw, 420px);

--- a/src/style.css
+++ b/src/style.css
@@ -63,6 +63,74 @@ img {
   line-height: 1;
 }
 
+.project-dropdown {
+  position: fixed;
+  display: none;
+  top: 0;
+  left: 0;
+  transform: translateX(-50%);
+  background: #fff;
+  border: 1px solid #000;
+  border-radius: 12px;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.16);
+  padding: 0.5rem 0;
+  max-height: min(70vh, 420px);
+  max-width: min(90vw, 420px);
+  overflow-y: auto;
+  z-index: 140;
+}
+
+.project-dropdown.is-open {
+  display: block;
+}
+
+.project-dropdown-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.project-dropdown-item {
+  margin: 0;
+}
+
+.project-dropdown-button {
+  display: block;
+  width: 100%;
+  padding: 0.55rem 1.25rem;
+  text-align: left;
+  background: transparent;
+  border: none;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.35;
+  color: #000;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.project-dropdown-button:hover,
+.project-dropdown-button:focus-visible {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.project-dropdown-button:focus-visible {
+  outline: 2px solid #000;
+  outline-offset: -2px;
+}
+
+.project-dropdown-button.is-active {
+  background: rgba(0, 0, 0, 0.12);
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .project-dropdown-button {
+    font-size: 0.95rem;
+    padding: 0.5rem 1rem;
+  }
+}
+
 
 
 

--- a/src/utils/navButtons.js
+++ b/src/utils/navButtons.js
@@ -1,11 +1,11 @@
 import Matter from 'matter-js';
 import { measureTextDimensions } from './generalUtils.js';
 import {
-  COLORS,
   getRandomColor,
   getNavHighlightColor,
   setNavHighlightColor
 } from './colorSystem.js';
+import projectsData from '../data/projects.json';
 
 export function pickRandomPrimary(exclude = []) {
   return getRandomColor(exclude);
@@ -20,9 +20,11 @@ export function pickRandomPrimary(exclude = []) {
  */
 export function createPhysicsNavMenu(world, container, currentPage) {
   const navButtons = [
-    { label: 'who?', path: '/who', id: 'who' },
-    { label: '?',    path: '/',    id: 'home' },
-    { label: 'what?', path: '/what', id: 'what' }
+    { label: 'who?', path: '/who', id: 'who', type: 'link' },
+    currentPage === '/what'
+      ? { label: 'list', id: 'project-list', type: 'list' }
+      : { label: '?', path: '/', id: 'home', type: 'link' },
+    { label: 'what?', path: '/what', id: 'what', type: 'link' }
   ];
 
   if (!getNavHighlightColor()) {
@@ -34,24 +36,146 @@ export function createPhysicsNavMenu(world, container, currentPage) {
   const margin = 18; // Smallest gap from edge (adjust to taste)
   const y = 30;      // Vertically near the top
 
+  const cleanupHandlers = Array.isArray(container.__navMenuCleanup)
+    ? container.__navMenuCleanup
+    : null;
+
+  let dropdownEl = null;
+  let dropdownButtons = [];
+  let isDropdownOpen = false;
+  let currentAnchor = null;
+  let latestProjectIndex = 0;
+
+  const highlightProjectInDropdown = (index) => {
+    if (!dropdownButtons.length) return;
+    dropdownButtons.forEach((button, idx) => {
+      if (idx === index) {
+        button.classList.add('is-active');
+        button.setAttribute('aria-current', 'true');
+      } else {
+        button.classList.remove('is-active');
+        button.removeAttribute('aria-current');
+      }
+    });
+  };
+
+  const closeDropdown = () => {
+    if (!dropdownEl) return;
+    dropdownEl.classList.remove('is-open');
+    dropdownEl.setAttribute('aria-hidden', 'true');
+    dropdownEl.style.display = 'none';
+    if (currentAnchor) {
+      currentAnchor.setAttribute('aria-expanded', 'false');
+    }
+    isDropdownOpen = false;
+  };
+
+  const updateDropdownPosition = () => {
+    if (!dropdownEl || !currentAnchor) return;
+    const rect = currentAnchor.getBoundingClientRect();
+    dropdownEl.style.left = `${rect.left + rect.width / 2}px`;
+    dropdownEl.style.top = `${rect.bottom + 12}px`;
+    dropdownEl.style.minWidth = `${rect.width}px`;
+  };
+
+  const handleProjectChange = (event) => {
+    const { index } = event.detail || {};
+    if (typeof index === 'number') {
+      latestProjectIndex = index;
+      highlightProjectInDropdown(index);
+      closeDropdown();
+    }
+  };
+
+  window.addEventListener('whatProjectChanged', handleProjectChange);
+  cleanupHandlers?.push(() => {
+    window.removeEventListener('whatProjectChanged', handleProjectChange);
+  });
+
+  const ensureDropdown = () => {
+    if (dropdownEl || currentPage !== '/what') return;
+
+    dropdownEl = document.createElement('div');
+    dropdownEl.className = 'project-dropdown';
+    dropdownEl.setAttribute('role', 'menu');
+    dropdownEl.setAttribute('aria-hidden', 'true');
+    dropdownEl.style.position = 'fixed';
+    dropdownEl.style.transform = 'translateX(-50%)';
+    dropdownEl.style.display = 'none';
+
+    const listEl = document.createElement('ul');
+    listEl.className = 'project-dropdown-list';
+    dropdownEl.appendChild(listEl);
+
+    dropdownButtons = projectsData.projects.map((project, index) => {
+      const itemEl = document.createElement('li');
+      itemEl.className = 'project-dropdown-item';
+
+      const buttonEl = document.createElement('button');
+      buttonEl.type = 'button';
+      buttonEl.textContent = project.title;
+      buttonEl.className = 'project-dropdown-button';
+      buttonEl.addEventListener('click', (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+        window.dispatchEvent(new CustomEvent('whatProjectListSelect', {
+          detail: { index }
+        }));
+        closeDropdown();
+      });
+      buttonEl.addEventListener('pointerdown', (event) => {
+        event.stopPropagation();
+      });
+
+      itemEl.appendChild(buttonEl);
+      listEl.appendChild(itemEl);
+      return buttonEl;
+    });
+
+    dropdownEl.addEventListener('pointerdown', (event) => {
+      event.stopPropagation();
+    });
+
+    container.appendChild(dropdownEl);
+
+    const handleOutsidePointer = (event) => {
+      if (!dropdownEl || !isDropdownOpen) return;
+      if (dropdownEl.contains(event.target) || (currentAnchor && currentAnchor.contains(event.target))) {
+        return;
+      }
+      closeDropdown();
+    };
+
+    window.addEventListener('pointerdown', handleOutsidePointer);
+    cleanupHandlers?.push(() => {
+      window.removeEventListener('pointerdown', handleOutsidePointer);
+    });
+
+    const handleResize = () => {
+      if (!isDropdownOpen) return;
+      updateDropdownPosition();
+    };
+
+    window.addEventListener('resize', handleResize);
+    cleanupHandlers?.push(() => {
+      window.removeEventListener('resize', handleResize);
+    });
+
+    highlightProjectInDropdown(latestProjectIndex);
+  };
+
   navButtons.forEach((btn, index) => {
-    // Use helper for dimensions
     const { width, height } = measureTextDimensions(btn.label, 'nav-button');
 
-    // Placement: left, center, right
     let x;
     if (index === 0) {
-      // Left edge: half width + margin
       x = margin + width / 2;
     } else if (index === 1) {
-      // Center: exactly centered
       x = window.innerWidth / 2;
     } else if (index === 2) {
-      // Right edge: window width - half width - margin
       x = window.innerWidth - margin - width / 2;
     }
 
-    // DOM setup
     const el = document.createElement('div');
     el.textContent = btn.label;
     el.className = 'nav-button';
@@ -60,11 +184,13 @@ export function createPhysicsNavMenu(world, container, currentPage) {
     el.style.userSelect = 'none';
     el.style.background = 'transparent';
 
-    // Highlight logic (NO underline)
     const isActive =
-      (currentPage === '/' && btn.id === 'home') ||
-      (currentPage === '/who' && btn.id === 'who') ||
-      (currentPage === '/what' && btn.id === 'what');
+      btn.type === 'link' && (
+        (currentPage === '/' && btn.id === 'home') ||
+        (currentPage === '/who' && btn.id === 'who') ||
+        (currentPage === '/what' && btn.id === 'what')
+      );
+
     if (isActive) {
       el.style.color = highlightColor;
       el.style.textDecoration = 'none';
@@ -84,24 +210,55 @@ export function createPhysicsNavMenu(world, container, currentPage) {
       });
     }
 
-    // store reference for hover exclusions
     btn.el = el;
 
-    // SPA navigation
-    el.addEventListener('click', (e) => {
-      e.stopPropagation();
-      if (window.location.pathname !== btn.path) {
-        const color = el.dataset.currentColor || getRandomColor([highlightColor]);
-        setNavHighlightColor(color);
-        history.pushState({}, '', btn.path);
-        window.dispatchEvent(new PopStateEvent('popstate'));
-      }
-    });
+    if (btn.type === 'link') {
+      el.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (btn.path && window.location.pathname !== btn.path) {
+          const color = el.dataset.currentColor || getRandomColor([highlightColor]);
+          setNavHighlightColor(color);
+          history.pushState({}, '', btn.path);
+          window.dispatchEvent(new PopStateEvent('popstate'));
+        }
+      });
+    } else if (btn.type === 'list') {
+      el.setAttribute('role', 'button');
+      el.setAttribute('tabindex', '0');
+      el.setAttribute('aria-haspopup', 'true');
+      el.setAttribute('aria-expanded', 'false');
+      el.addEventListener('pointerdown', (event) => {
+        event.stopPropagation();
+      });
+      const toggleDropdown = () => {
+        ensureDropdown();
+        if (!dropdownEl) return;
+        if (isDropdownOpen) {
+          closeDropdown();
+        } else {
+          currentAnchor = el;
+          updateDropdownPosition();
+          dropdownEl.style.display = 'block';
+          dropdownEl.classList.add('is-open');
+          dropdownEl.setAttribute('aria-hidden', 'false');
+          el.setAttribute('aria-expanded', 'true');
+          isDropdownOpen = true;
+        }
+      };
+      el.addEventListener('click', (event) => {
+        event.stopPropagation();
+        toggleDropdown();
+      });
+      el.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          toggleDropdown();
+        }
+      });
+    }
 
-    // Add to DOM and physics
     container.appendChild(el);
 
-    // Physics: TIGHT bounding box, no added spacing
     const body = Matter.Bodies.rectangle(x, y, width, height, {
       isStatic: true
     });

--- a/src/utils/navButtons.js
+++ b/src/utils/navButtons.js
@@ -41,14 +41,14 @@ export function createPhysicsNavMenu(world, container, currentPage) {
     : null;
 
   let dropdownEl = null;
-  let dropdownButtons = [];
+  let projectButtons = [];
   let isDropdownOpen = false;
   let currentAnchor = null;
   let latestProjectIndex = 0;
 
   const highlightProjectInDropdown = (index) => {
-    if (!dropdownButtons.length) return;
-    dropdownButtons.forEach((button, idx) => {
+    if (!projectButtons.length) return;
+    projectButtons.forEach((button, idx) => {
       if (idx === index) {
         button.classList.add('is-active');
         button.setAttribute('aria-current', 'true');
@@ -66,8 +66,12 @@ export function createPhysicsNavMenu(world, container, currentPage) {
     dropdownEl.style.display = 'none';
     if (currentAnchor) {
       currentAnchor.setAttribute('aria-expanded', 'false');
+      currentAnchor.classList.remove('is-open');
+      currentAnchor.style.color = '#000';
+      currentAnchor.dataset.currentColor = '';
     }
     isDropdownOpen = false;
+    currentAnchor = null;
   };
 
   const updateDropdownPosition = () => {
@@ -107,7 +111,7 @@ export function createPhysicsNavMenu(world, container, currentPage) {
     listEl.className = 'project-dropdown-list';
     dropdownEl.appendChild(listEl);
 
-    dropdownButtons = projectsData.projects.map((project, index) => {
+    projectButtons = projectsData.projects.map((project, index) => {
       const itemEl = document.createElement('li');
       itemEl.className = 'project-dropdown-item';
 
@@ -131,6 +135,33 @@ export function createPhysicsNavMenu(world, container, currentPage) {
       listEl.appendChild(itemEl);
       return buttonEl;
     });
+
+    const contactItemEl = document.createElement('li');
+    contactItemEl.className = 'project-dropdown-item';
+
+    const contactButtonEl = document.createElement('button');
+    contactButtonEl.type = 'button';
+    contactButtonEl.textContent = 'contact';
+    contactButtonEl.className = 'project-dropdown-button project-dropdown-button-contact';
+    contactButtonEl.addEventListener('click', (event) => {
+      event.stopPropagation();
+      event.preventDefault();
+      const color = currentAnchor?.dataset.currentColor || highlightColor;
+      if (color) {
+        setNavHighlightColor(color);
+      }
+      window.__whoPendingAnchor = 'contact';
+      const nextState = { ...(history.state || {}), whoAutoSpawn: 'contact' };
+      history.pushState(nextState, '', '/who');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      closeDropdown();
+    });
+    contactButtonEl.addEventListener('pointerdown', (event) => {
+      event.stopPropagation();
+    });
+
+    contactItemEl.appendChild(contactButtonEl);
+    listEl.appendChild(contactItemEl);
 
     dropdownEl.addEventListener('pointerdown', (event) => {
       event.stopPropagation();
@@ -205,6 +236,9 @@ export function createPhysicsNavMenu(world, container, currentPage) {
         el.dataset.currentColor = c;
       });
       el.addEventListener('mouseleave', () => {
+        if (btn.type === 'list' && isDropdownOpen && currentAnchor === el) {
+          return;
+        }
         el.style.color = '#000';
         el.dataset.currentColor = '';
       });
@@ -242,6 +276,12 @@ export function createPhysicsNavMenu(world, container, currentPage) {
           dropdownEl.classList.add('is-open');
           dropdownEl.setAttribute('aria-hidden', 'false');
           el.setAttribute('aria-expanded', 'true');
+          el.classList.add('is-open');
+          const color = el.dataset.currentColor || highlightColor;
+          if (color) {
+            el.style.color = color;
+            el.dataset.currentColor = color;
+          }
           isDropdownOpen = true;
         }
       };

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -52,6 +52,84 @@ const DESKTOP_SCALING = { // Original scales you were using
   button: 1.0,
 };
 
+const clampValue = (value, min, max) => {
+  if (!Number.isFinite(value)) {
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      return (min + max) / 2;
+    }
+    return 0;
+  }
+  if (min > max) {
+    return Number.isFinite(min) && Number.isFinite(max)
+      ? (min + max) / 2
+      : value;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const computeViewportMargins = (viewportWidth, viewportHeight) => {
+  const marginX = Math.min(Math.max(viewportWidth * 0.06, 32), viewportWidth / 3);
+  const marginY = Math.min(Math.max(viewportHeight * 0.1, 48), viewportHeight / 3);
+  return { marginX, marginY };
+};
+
+const createScatterPlanner = (totalCount, viewportWidth, viewportHeight) => {
+  const count = Math.max(totalCount, 1);
+  const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
+  const rows = Math.max(1, Math.ceil(count / columns));
+  const { marginX, marginY } = computeViewportMargins(viewportWidth, viewportHeight);
+  const jitterScale = 0.35;
+  let index = 0;
+
+  return ({ width = 0, height = 0 } = {}) => {
+    const currentIndex = index;
+    index += 1;
+
+    if (currentIndex >= count) {
+      return {
+        x: viewportWidth / 2,
+        y: viewportHeight / 2,
+      };
+    }
+
+    const row = Math.floor(currentIndex / columns);
+    let col = currentIndex % columns;
+    if (row % 2 === 1) {
+      col = columns - 1 - col;
+    }
+
+    const columnSpan = Math.max(columns - 1, 1);
+    const rowSpan = Math.max(rows - 1, 1);
+    const baseX = columns === 1 ? 0.5 : col / columnSpan;
+    const baseY = rows === 1 ? 0.5 : row / rowSpan;
+
+    const cellWidth = 1 / columns;
+    const cellHeight = 1 / rows;
+    const jitterX = (Math.random() - 0.5) * cellWidth * jitterScale;
+    const jitterY = (Math.random() - 0.5) * cellHeight * jitterScale;
+
+    const normalizedX = Math.min(Math.max(baseX + jitterX, 0), 1);
+    const normalizedY = Math.min(Math.max(baseY + jitterY, 0), 1);
+
+    const halfWidth = width / 2;
+    const halfHeight = height / 2;
+
+    const minX = marginX + halfWidth;
+    const maxX = viewportWidth - marginX - halfWidth;
+    const minY = marginY + halfHeight;
+    const maxY = viewportHeight - marginY - halfHeight;
+
+    const resolvedX = minX <= maxX
+      ? minX + normalizedX * (maxX - minX)
+      : viewportWidth / 2;
+    const resolvedY = minY <= maxY
+      ? minY + normalizedY * (maxY - minY)
+      : viewportHeight / 2;
+
+    return { x: resolvedX, y: resolvedY };
+  };
+};
+
 export function setupWhatPhysics() {
   // --- Step 1: Initialization and Variable Scoping ---
   const engine = initializeMatterEngine();
@@ -238,7 +316,7 @@ export function setupWhatPhysics() {
     { x: window.innerWidth / 2, y: amIMobile ? window.innerHeight * 0.9 : window.innerHeight / 2 }
   );
 
-  async function addProjectElement(elementData, spawnX, spawnY) {
+  async function addProjectElement(elementData, spawnX, spawnY, placementCallback) {
     let domElement, measuredWidth, measuredHeight;
     let ro; // ResizeObserver for text elements, if created
     
@@ -383,16 +461,60 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     domElement.style.position = 'absolute';
     domElement.style.userSelect = 'none';
     domElement.setAttribute('draggable', 'false');
-    
-    // Re-measure DOM element for visual reference if needed, but physics body uses scaled values
-    // const finalRect = domElement.getBoundingClientRect();
-    // Note: measuredWidth and measuredHeight are now the SIZED values for the physics body
+
+    const bodyWidth = measuredWidth > 0 ? measuredWidth : 50;
+    const bodyHeight = measuredHeight > 0 ? measuredHeight : 20;
+
+    let resolvedX = spawnX;
+    let resolvedY = spawnY;
+    const usingPlanner = typeof placementCallback === 'function';
+
+    if (usingPlanner) {
+      try {
+        const plannedPosition = placementCallback({ width: bodyWidth, height: bodyHeight });
+        if (plannedPosition && Number.isFinite(plannedPosition.x) && Number.isFinite(plannedPosition.y)) {
+          resolvedX = plannedPosition.x;
+          resolvedY = plannedPosition.y;
+        }
+      } catch (error) {
+        console.error('Failed to resolve auto-spawn position', error);
+      }
+    }
+
+    if (usingPlanner) {
+      const { marginX, marginY } = computeViewportMargins(window.innerWidth, window.innerHeight);
+      const minX = marginX + bodyWidth / 2;
+      const maxX = window.innerWidth - marginX - bodyWidth / 2;
+      const minY = marginY + bodyHeight / 2;
+      const maxY = window.innerHeight - marginY - bodyHeight / 2;
+
+      if (!Number.isFinite(resolvedX)) {
+        resolvedX = minX <= maxX
+          ? minX + Math.random() * (maxX - minX)
+          : window.innerWidth / 2;
+      }
+      if (!Number.isFinite(resolvedY)) {
+        resolvedY = minY <= maxY
+          ? minY + Math.random() * (maxY - minY)
+          : window.innerHeight / 2;
+      }
+
+      resolvedX = clampValue(resolvedX, minX, maxX);
+      resolvedY = clampValue(resolvedY, minY, maxY);
+    } else {
+      if (!Number.isFinite(resolvedX)) {
+        resolvedX = Math.random() * window.innerWidth;
+      }
+      if (!Number.isFinite(resolvedY)) {
+        resolvedY = Math.random() * window.innerHeight;
+      }
+    }
 
     const body = Matter.Bodies.rectangle(
-      (typeof spawnX === 'number') ? spawnX : Math.random() * window.innerWidth,
-      (typeof spawnY === 'number') ? spawnY : Math.random() * window.innerHeight,
-      measuredWidth > 0 ? measuredWidth : 50,
-      measuredHeight > 0 ? measuredHeight : 20,
+      resolvedX,
+      resolvedY,
+      bodyWidth,
+      bodyHeight,
       { restitution: 0.9, friction: 0.05 }
     );
     Matter.World.add(world, body);
@@ -666,11 +788,6 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     }));
   }
 
-  const autoSpawnOffset = () => {
-    const base = Math.max(Math.min(window.innerWidth, window.innerHeight) * 0.25, 120);
-    return (Math.random() - 0.5) * base;
-  };
-
   async function completeProjectInstantly(targetIndex) {
     await waitForSpawnIdle();
     spawnInProgress = true;
@@ -680,12 +797,18 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       const summaryElements = projects[currentProjectIndex].summary.elements;
       const centerX = window.innerWidth / 2;
       const centerY = window.innerHeight / 2;
+      const placementPlanner = createScatterPlanner(
+        summaryElements.length,
+        window.innerWidth,
+        window.innerHeight
+      );
 
       for (const elementData of summaryElements) {
         await addProjectElement(
           elementData,
-          centerX + autoSpawnOffset(),
-          centerY + autoSpawnOffset()
+          undefined,
+          undefined,
+          placementPlanner
         );
       }
 

--- a/src/utils/whatPhysics.js
+++ b/src/utils/whatPhysics.js
@@ -93,6 +93,7 @@ export function setupWhatPhysics() {
   container.classList.add('container');
   container.style.touchAction = 'none'; // Crucial for custom pointer/touch handling
   container.style.cursor = `url('${import.meta.env.BASE_URL}cursors/just-click.svg') 32 32, auto`;
+  container.__navMenuCleanup = [];
   document.body.appendChild(container);
 
   // --- Step 5: Project Data and State ---
@@ -115,6 +116,17 @@ export function setupWhatPhysics() {
   let holdButtonDom = null;
   const preloadedIndices = new Set();
   let spawnInProgress = false;
+
+  const waitForSpawnIdle = () => new Promise((resolve) => {
+    const check = () => {
+      if (!spawnInProgress) {
+        resolve();
+      } else {
+        requestAnimationFrame(check);
+      }
+    };
+    check();
+  });
 
   function updateWhitespaceCursor() {
     const summaryElements = projects[currentProjectIndex].summary.elements;
@@ -173,6 +185,42 @@ export function setupWhatPhysics() {
     dom.style.touchAction = 'none';
   }
   attachTitleInterception(titleDom);
+
+  const completionJitter = () => (Math.random() * 40) - 20;
+
+  async function addCompletionElements(baseX, baseY) {
+    const x = typeof baseX === 'number' ? baseX : window.innerWidth / 2;
+    const y = typeof baseY === 'number' ? baseY : window.innerHeight / 2;
+
+    const fullData = {
+      type: 'button',
+      content: 'view full project',
+      cssClass: 'view-full-project-button',
+      action: 'openFullProject'
+    };
+    await addProjectElement(fullData, x + completionJitter(), y + completionJitter());
+
+    if (amIMobile) {
+      const holdData = {
+        type: 'button',
+        content: 'hold for next',
+        cssClass: 'hold-next-button'
+      };
+      const { domElement } = await addProjectElement(
+        holdData,
+        x + completionJitter(),
+        y + completionJitter()
+      );
+      holdButtonDom = domElement;
+    } else {
+      holdButtonDom = null;
+    }
+
+    const color = pickRandomPrimary([lastTitleColor]);
+    titleDom.dataset.highlightColor = color;
+    markDone(titleDom);
+    lastTitleColor = color;
+  }
 
   if (!preloadedIndices.has(currentProjectIndex)) {
     preloadedIndices.add(currentProjectIndex);
@@ -379,6 +427,9 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
   // --- Step 9: General Navigation Menu ---
   const navMenuBodies = createPhysicsNavMenu(world, container, '/what');
   bodies.push(...navMenuBodies);
+  window.dispatchEvent(new CustomEvent('whatProjectChanged', {
+    detail: { index: currentProjectIndex }
+  }));
 
   // --- Step 10: Pointer Event Handling for Spawning ---
   let pointerDownPos = null;
@@ -398,8 +449,10 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       amIMobile &&
       currentElementIndex >= projects[currentProjectIndex].summary.elements.length &&
       !(e.target.classList.contains('view-full-project-button') ||
+        e.target.classList.contains('hold-next-button') ||
         e.target.closest('.nav-button') ||
-        e.target.closest('.what-nav-button'))
+        e.target.closest('.what-nav-button') ||
+        e.target.closest('.project-dropdown'))
     ) {
       longPressFired = false;
       longPressTimer = setTimeout(() => {
@@ -473,7 +526,8 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
         if (e.target.classList.contains('view-full-project-button') ||
             e.target.classList.contains('hold-next-button') ||
             e.target.closest('.nav-button') || // General nav
-            e.target.closest('.what-nav-button')) { // Project-specific nav (ensure this class is used in whatNav.js)
+            e.target.closest('.what-nav-button') ||
+            e.target.closest('.project-dropdown')) { // Project-specific nav (whatNav.js) or dropdown list
         pointerDownPos = null; // Reset, but let the button's own click handler fire
         return;
       }
@@ -523,32 +577,7 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
       currentElementIndex++;
       updateWhitespaceCursor();
       if (currentElementIndex === summaryElements.length) {
-        const fullData = {
-          type: 'button',
-          content: 'view full project',
-          cssClass: 'view-full-project-button',
-          action: 'openFullProject'
-        };
-        await addProjectElement(fullData, x + (Math.random()*40-20), y + (Math.random()*40-20));
-
-        if (amIMobile) {
-          const holdData = {
-            type: 'button',
-            content: 'hold for next',
-            cssClass: 'hold-next-button'
-          };
-          const { domElement } = await addProjectElement(
-            holdData,
-            x + (Math.random()*40-20),
-            y + (Math.random()*40-20)
-          );
-          holdButtonDom = domElement;
-        }
-
-        const color = pickRandomPrimary([lastTitleColor]);
-        titleDom.dataset.highlightColor = color;
-        markDone(titleDom);
-        lastTitleColor = color;
+        await addCompletionElements(x, y);
       }
     } else {
       if (!amIMobile) {
@@ -632,8 +661,43 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
         setGravity(engine, newGravity.x, newGravity.y);
     }
     updateSpecificNav();
+    window.dispatchEvent(new CustomEvent('whatProjectChanged', {
+      detail: { index: currentProjectIndex }
+    }));
   }
-  
+
+  const autoSpawnOffset = () => {
+    const base = Math.max(Math.min(window.innerWidth, window.innerHeight) * 0.25, 120);
+    return (Math.random() - 0.5) * base;
+  };
+
+  async function completeProjectInstantly(targetIndex) {
+    await waitForSpawnIdle();
+    spawnInProgress = true;
+    try {
+      handleProjectNavigation(targetIndex);
+
+      const summaryElements = projects[currentProjectIndex].summary.elements;
+      const centerX = window.innerWidth / 2;
+      const centerY = window.innerHeight / 2;
+
+      for (const elementData of summaryElements) {
+        await addProjectElement(
+          elementData,
+          centerX + autoSpawnOffset(),
+          centerY + autoSpawnOffset()
+        );
+      }
+
+      currentElementIndex = summaryElements.length;
+      updateWhitespaceCursor();
+
+      await addCompletionElements(centerX, centerY);
+    } finally {
+      spawnInProgress = false;
+    }
+  }
+
   // Define the handler for the custom event
   const handleWhatProjectNavEvent = (e) => {
     const { target } = e.detail;
@@ -650,6 +714,19 @@ const { width: rawW, height: rawH } = await measureTextDimensionsAfterFonts(
     }
   };
   window.addEventListener('whatProjectNav', handleWhatProjectNavEvent);
+
+  const handleProjectListSelect = async (event) => {
+    const { index } = event.detail || {};
+    if (typeof index !== 'number' || index < 0 || index >= projects.length) {
+      return;
+    }
+    try {
+      await completeProjectInstantly(index);
+    } catch (error) {
+      console.error('Failed to complete project from list button', error);
+    }
+  };
+  window.addEventListener('whatProjectListSelect', handleProjectListSelect);
 
   // --- Step 14: Start DOM Syncing, Dragging, and Matter.js Runner ---
   // Store the returned cleanup function from syncDOMWithBodies
@@ -702,7 +779,20 @@ if (DEBUG) {
     container.removeEventListener('pointerup', handlePointerUp);
     container.removeEventListener('pointercancel', handlePointerCancel);
     window.removeEventListener('whatProjectNav', handleWhatProjectNavEvent);
+    window.removeEventListener('whatProjectListSelect', handleProjectListSelect);
     // console.log('Custom and pointer listeners removed.');
+
+    if (Array.isArray(container.__navMenuCleanup)) {
+      container.__navMenuCleanup.forEach((fn) => {
+        try {
+          fn();
+        } catch (error) {
+          // ignore cleanup errors
+        }
+      });
+      container.__navMenuCleanup.length = 0;
+      container.__navMenuCleanup = null;
+    }
 
     // B. Call cleanup functions for ongoing processes
     if (cleanupSyncLoop) {

--- a/src/utils/whoPhysics.js
+++ b/src/utils/whoPhysics.js
@@ -123,6 +123,7 @@ function createAnchors(world, container, bodies, isOnMobile) {
   const spawnedAnchors = new Set();
   const colorCycle = shuffleColors();
   let colorIndex = 0;
+  const anchorControls = new Map();
 
   ANCHORS.forEach((anchor) => {
     // Get position using the new system
@@ -183,46 +184,56 @@ function createAnchors(world, container, bodies, isOnMobile) {
     // --- MODIFICATION FOR TOUCH & CLICK ---
     let lastTouchCoords = null;
 
+    const spawnAnchor = (coords, options = {}) => {
+      if (spawnedAnchors.has(anchor.id) && !options.force) return false;
+      spawnedAnchors.add(anchor.id);
+
+      const coordsToUse = coords || { clientX: x, clientY: y };
+
+      anchor.microTexts.forEach((micro, microIdx) => {
+        spawnMicroText(world, container, bodies, micro, coordsToUse, microIdx);
+      });
+
+      markDone(el);
+      lastTouchCoords = null;
+      return true;
+    };
+
+    anchorControls.set(anchor.id, {
+      element: el,
+      spawn: spawnAnchor,
+    });
+
     // Listen to touchend to capture coordinates
     el.addEventListener('touchend', (touchEvent) => {
-      // Prevent click if touchend is part of a drag/scroll
-      if (touchEvent.cancelable) { // Check if it can be cancelled
-          // A simple check: if the touch moved significantly, it might be a scroll.
-          // This is a basic heuristic. For robust drag detection, you'd need more.
-          // For now, let's assume a tap doesn't move much.
-      }
       if (touchEvent.changedTouches && touchEvent.changedTouches.length > 0) {
         lastTouchCoords = {
           clientX: touchEvent.changedTouches[0].clientX,
           clientY: touchEvent.changedTouches[0].clientY,
         };
       }
-      // We don't preventDefault here usually, to allow the click event to fire.
-      // However, if double spawning occurs, you might need to manage it.
-    }, { passive: true }); // Use passive for touchend if not preventing default scroll
+    }, { passive: true });
 
     el.addEventListener('click', (clickEvent) => {
-      if (spawnedAnchors.has(anchor.id)) return;
-      spawnedAnchors.add(anchor.id);
-
-      // Determine the event coordinates to use for spawning
-      const coordsToUse = lastTouchCoords || { // Prioritize last touch coordinates
+      const coordsToUse = lastTouchCoords || {
         clientX: clickEvent.clientX,
         clientY: clickEvent.clientY,
       };
-
-      anchor.microTexts.forEach((micro, microIdx) => {
-        // Pass the determined coordinates (either from touch or click)
-        spawnMicroText(world, container, bodies, micro, coordsToUse, microIdx);
-      });
-
-      // Mark anchor as done and keep its highlight colour
-      markDone(el);
-
-      lastTouchCoords = null; // Reset for the next interaction
+      spawnAnchor(coordsToUse);
     });
     // --- END MODIFICATION ---
   });
+
+  return {
+    spawnAnchorById(anchorId, coords, options) {
+      const control = anchorControls.get(anchorId);
+      if (!control) return false;
+      return control.spawn(coords, options);
+    },
+    getAnchorElement(anchorId) {
+      return anchorControls.get(anchorId)?.element || null;
+    },
+  };
 }
 
 function addRagdoll(world, container, bodies, currentlyIsMobile) {
@@ -544,7 +555,36 @@ export function setupWhoPhysics() {
 
   // 5. Anchors (with new fractional positioning)
   const isOnMobile = window.innerWidth <= 768;
-  createAnchors(world, container, bodies, isOnMobile);
+  const anchorAPI = createAnchors(world, container, bodies, isOnMobile);
+
+  let pendingAnchorId = null;
+  if (typeof window.__whoPendingAnchor === 'string') {
+    pendingAnchorId = window.__whoPendingAnchor;
+  }
+  window.__whoPendingAnchor = null;
+
+  const historyAutoSpawn =
+    history.state && typeof history.state.whoAutoSpawn === 'string'
+      ? history.state.whoAutoSpawn
+      : null;
+
+  if (!pendingAnchorId && historyAutoSpawn) {
+    pendingAnchorId = historyAutoSpawn;
+  }
+
+  if (pendingAnchorId) {
+    requestAnimationFrame(() => {
+      anchorAPI.spawnAnchorById(pendingAnchorId);
+    });
+  }
+
+  const handleWhoTriggerAnchor = (event) => {
+    const detail = event?.detail || {};
+    const { anchorId, coords, options } = detail;
+    if (typeof anchorId !== 'string') return;
+    anchorAPI.spawnAnchorById(anchorId, coords, options);
+  };
+  window.addEventListener('whoTriggerAnchor', handleWhoTriggerAnchor);
 
   const highlightColor = getNavHighlightColor() || COLORS[0];
   const cleanupHighlight = enableHighlightOnTouch(engine, bodies, { highlightColor });
@@ -614,6 +654,8 @@ export function setupWhoPhysics() {
     if (cleanupHighlight) {
       cleanupHighlight();
     }
+
+    window.removeEventListener('whoTriggerAnchor', handleWhoTriggerAnchor);
 
     // Debug Renderer Cleanup
     if (DEBUG_WHO_PAGE && matterRenderInstance) {


### PR DESCRIPTION
## Summary
- replace the central "?" button on the what page with a "list" dropdown that enumerates projects
- allow selecting a project from the dropdown to auto-spawn all of its summary elements and update nav highlights
- add dropdown styling plus cleanup hooks so the menu closes correctly and doesn’t interfere with physics interactions

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caccf31c68832cadb14a446e714cbf